### PR TITLE
Reorganize gh-pages deployment structure with docs subdirectory

### DIFF
--- a/.github/workflows/on-release-main.yml
+++ b/.github/workflows/on-release-main.yml
@@ -99,8 +99,11 @@ jobs:
           cd gh-pages-deploy
           # Remove everything except .git and pr-preview
           find . -maxdepth 1 ! -name '.' ! -name '.git' ! -name 'pr-preview' -exec rm -rf {} +
-          # Copy new site content
-          cp -r ../site/. .
+          # Copy root-level files (CNAME, redirect index.html)
+          cp -r ../gh-pages-extra/. .
+          # Copy built docs into /docs subdirectory
+          mkdir -p docs
+          cp -r ../site/. docs/
           touch .nojekyll
 
           git config user.name "github-actions[bot]"


### PR DESCRIPTION
## Summary
This change reorganizes the GitHub Pages deployment structure to separate root-level files (like CNAME and redirect index.html) from the built documentation content.

## Key Changes
- Modified the gh-pages deployment script to copy root-level files from `gh-pages-extra/` directory instead of directly from the built `site/` directory
- Built documentation is now deployed into a `/docs` subdirectory rather than at the repository root
- The `.nojekyll` file continues to be placed at the root level

## Implementation Details
The deployment workflow now follows a two-step copy process:
1. First, copies root-level configuration files (CNAME, redirect index.html, etc.) from `gh-pages-extra/` to the gh-pages root
2. Then, creates a `docs/` subdirectory and copies all built site content into it

This structure allows for better organization of static site content while maintaining root-level configuration files needed for GitHub Pages functionality.

https://claude.ai/code/session_01Q2xRsGY4qgK7mK4o1EuToM