### PR TITLE
Add MCP tool annotations and OpenAI SDK compatibility

### DIFF
--- a/src/idfkit_mcp/errors.py
+++ b/src/idfkit_mcp/errors.py
@@ -2,7 +2,26 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
+from functools import wraps
 from typing import Any
+
+
+def safe_tool(func: Callable[..., dict[str, Any]]) -> Callable[..., dict[str, Any]]:
+    """Convert exceptions into MCP-friendly error dicts.
+
+    Decorator for MCP tool functions that catches all exceptions and returns
+    structured error responses instead of raising.
+    """
+
+    @wraps(func)
+    def wrapper(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        try:
+            return func(*args, **kwargs)
+        except Exception as e:
+            return format_error(e)
+
+    return wrapper
 
 
 def format_error(error: Exception) -> dict[str, Any]:

--- a/src/idfkit_mcp/server.py
+++ b/src/idfkit_mcp/server.py
@@ -27,7 +27,14 @@ _INSTRUCTIONS = (
 
 
 def create_server(host: str = "127.0.0.1", port: int = 8000) -> FastMCP:
-    """Create a configured FastMCP instance and register all tools."""
+    """Create a configured FastMCP instance and register all tools.
+
+    TODO: Enable ``structured_output`` on tools once Pydantic return models
+    are defined for each tool function. This would populate both ``content``
+    (text) and ``structuredContent`` (typed JSON) in MCP responses, improving
+    compatibility with clients that consume structured tool output (e.g.
+    OpenAI Agents SDK ``convert_schemas_to_strict``).
+    """
     server = FastMCP("idfkit", instructions=_INSTRUCTIONS, host=host, port=port)
 
     schema.register(server)

--- a/src/idfkit_mcp/state.py
+++ b/src/idfkit_mcp/state.py
@@ -20,6 +20,11 @@ class ServerState:
     """Holds the active document, schema, and simulation result.
 
     MCP stdio transport is single-threaded, so a module-level instance is safe.
+
+    WARNING: For streamable-http or SSE transports with multiple concurrent
+    clients, this singleton will cause cross-session state contamination.
+    A future improvement should key state by session/connection ID using
+    FastMCP's ``context.session`` or a similar mechanism.
     """
 
     document: IDFDocument | None = None

--- a/src/idfkit_mcp/tools/read.py
+++ b/src/idfkit_mcp/tools/read.py
@@ -2,45 +2,24 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
-from functools import wraps
 from typing import Any, cast
 
 from mcp.server.fastmcp import FastMCP
+from mcp.types import ToolAnnotations
 
-from idfkit_mcp.errors import format_error
+from idfkit_mcp.errors import safe_tool
 from idfkit_mcp.serializers import serialize_object
 from idfkit_mcp.state import get_state
 
-
-def _safe_tool(func: Callable[..., dict[str, Any]]) -> Callable[..., dict[str, Any]]:
-    """Convert exceptions into MCP-friendly error dicts."""
-
-    @wraps(func)
-    def wrapper(*args: Any, **kwargs: Any) -> dict[str, Any]:
-        try:
-            return func(*args, **kwargs)
-        except Exception as e:
-            return format_error(e)
-
-    return wrapper
+_READ_ONLY = ToolAnnotations(readOnlyHint=True, destructiveHint=False, idempotentHint=True, openWorldHint=False)
+_LOAD = ToolAnnotations(readOnlyHint=False, destructiveHint=False, idempotentHint=True, openWorldHint=False)
 
 
-def register(mcp: FastMCP) -> None:
-    """Register read tools on the MCP server."""
-    mcp.tool()(load_model)
-    mcp.tool()(convert_osm_to_idf)
-    mcp.tool()(get_model_summary)
-    mcp.tool()(list_objects)
-    mcp.tool()(get_object)
-    mcp.tool()(search_objects)
-    mcp.tool()(get_references)
-
-
-@_safe_tool
+@safe_tool
 def load_model(file_path: str, version: str | None = None) -> dict[str, Any]:
-    """Load an IDF or epJSON file as the active model.
+    """Open an existing IDF or epJSON file as the active model.
 
+    Use this to load a building energy model for inspection or editing.
     Auto-detects format by file extension (.idf or .epjson/.json).
 
     Args:
@@ -71,7 +50,7 @@ def load_model(file_path: str, version: str | None = None) -> dict[str, Any]:
     return _build_summary(doc, state)
 
 
-@_safe_tool
+@safe_tool
 def convert_osm_to_idf(
     osm_path: str,
     output_path: str,
@@ -79,6 +58,8 @@ def convert_osm_to_idf(
     overwrite: bool = False,
 ) -> dict[str, Any]:
     """Convert an OpenStudio OSM model to IDF and load it as the active model.
+
+    Use this when working with OpenStudio models that need EnergyPlus simulation.
 
     Args:
         osm_path: Path to the source .osm file.
@@ -153,10 +134,11 @@ def convert_osm_to_idf(
     return summary
 
 
-@_safe_tool
+@safe_tool
 def get_model_summary() -> dict[str, Any]:
     """Get a summary of the currently loaded model.
 
+    Use this first after loading a model to understand its contents.
     Returns version, total objects, zone count, and counts by group/type.
     """
     state = get_state()
@@ -164,10 +146,11 @@ def get_model_summary() -> dict[str, Any]:
     return _build_summary(doc, state)
 
 
-@_safe_tool
+@safe_tool
 def list_objects(object_type: str, limit: int = 50) -> dict[str, Any]:
     """List objects of a given type from the loaded model.
 
+    Use this to browse existing objects before inspecting or editing them.
     Returns object names and required field values in brief format.
 
     Args:
@@ -187,9 +170,11 @@ def list_objects(object_type: str, limit: int = 50) -> dict[str, Any]:
     return {"object_type": object_type, "total": total, "returned": len(objects), "objects": objects}
 
 
-@_safe_tool
+@safe_tool
 def get_object(object_type: str, name: str) -> dict[str, Any]:
     """Get all field values for a specific object.
+
+    Use this to inspect the full details of a single object.
 
     Args:
         object_type: The EnergyPlus object type.
@@ -209,9 +194,11 @@ def get_object(object_type: str, name: str) -> dict[str, Any]:
     return serialize_object(obj)
 
 
-@_safe_tool
+@safe_tool
 def search_objects(query: str, object_type: str | None = None, limit: int = 20) -> dict[str, Any]:
     """Search for objects by name or field values.
+
+    Use this to find objects when you know a keyword but not the exact name or type.
 
     Args:
         query: Search string (case-insensitive substring match on name and string fields).
@@ -234,10 +221,11 @@ def search_objects(query: str, object_type: str | None = None, limit: int = 20) 
     return {"query": query, "count": len(matches), "matches": matches}
 
 
-@_safe_tool
+@safe_tool
 def get_references(name: str) -> dict[str, Any]:
     """Get bidirectional references for an object name.
 
+    Use this to understand dependencies before renaming or removing an object.
     Returns objects that reference this name, and names this object references.
 
     Args:
@@ -264,6 +252,24 @@ def get_references(name: str) -> dict[str, Any]:
         "references": references,
         "references_count": len(references),
     }
+
+
+# Annotations are defined after functions to avoid forward-reference errors.
+_TOOL_REGISTRY = [
+    (load_model, _LOAD),
+    (convert_osm_to_idf, _LOAD),
+    (get_model_summary, _READ_ONLY),
+    (list_objects, _READ_ONLY),
+    (get_object, _READ_ONLY),
+    (search_objects, _READ_ONLY),
+    (get_references, _READ_ONLY),
+]
+
+
+def register(mcp: FastMCP) -> None:
+    """Register read tools on the MCP server."""
+    for func, hints in _TOOL_REGISTRY:
+        mcp.tool(annotations=hints)(func)
 
 
 def _build_summary(doc: Any, state: Any) -> dict[str, Any]:

--- a/src/idfkit_mcp/tools/schema.py
+++ b/src/idfkit_mcp/tools/schema.py
@@ -2,15 +2,16 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
-from functools import wraps
 from typing import Any
 
 from mcp.server.fastmcp import FastMCP
+from mcp.types import ToolAnnotations
 
-from idfkit_mcp.errors import format_error
+from idfkit_mcp.errors import safe_tool
 from idfkit_mcp.serializers import serialize_object_description
 from idfkit_mcp.state import get_state
+
+_READ_ONLY = ToolAnnotations(readOnlyHint=True, destructiveHint=False, idempotentHint=True, openWorldHint=False)
 
 
 def _parse_version(version: str | None) -> tuple[int, int, int] | None:
@@ -24,30 +25,11 @@ def _parse_version(version: str | None) -> tuple[int, int, int] | None:
     return (int(parts[0]), int(parts[1]), int(parts[2]))
 
 
-def _safe_tool(func: Callable[..., dict[str, Any]]) -> Callable[..., dict[str, Any]]:
-    """Convert exceptions into MCP-friendly error dicts."""
-
-    @wraps(func)
-    def wrapper(*args: Any, **kwargs: Any) -> dict[str, Any]:
-        try:
-            return func(*args, **kwargs)
-        except Exception as e:
-            return format_error(e)
-
-    return wrapper
-
-
-def register(mcp: FastMCP) -> None:
-    """Register schema tools on the MCP server."""
-    mcp.tool()(list_object_types)
-    mcp.tool()(describe_object_type)
-    mcp.tool()(search_schema)
-    mcp.tool()(get_available_references)
-
-
-@_safe_tool
+@safe_tool
 def list_object_types(group: str | None = None, version: str | None = None, limit: int = 50) -> dict[str, Any]:
-    """List all EnergyPlus object types, optionally filtered by group.
+    """Discover available EnergyPlus object types, optionally filtered by group.
+
+    Use this to browse what object types exist before creating objects.
 
     When the total exceeds the limit, type names are omitted and only group
     names with counts are returned.  Filter by group to see individual types.
@@ -85,12 +67,12 @@ def list_object_types(group: str | None = None, version: str | None = None, limi
     }
 
 
-@_safe_tool
+@safe_tool
 def describe_object_type(object_type: str, version: str | None = None) -> dict[str, Any]:
-    """Get full field schema for an EnergyPlus object type.
+    """Get the full field schema for an EnergyPlus object type.
 
+    Use this before creating or editing objects to learn valid fields and constraints.
     Returns field names, types, constraints, defaults, references, and memo.
-    Call this before creating or editing objects to know valid fields.
 
     Args:
         object_type: The object type name (e.g. "Zone", "Material").
@@ -104,9 +86,11 @@ def describe_object_type(object_type: str, version: str | None = None) -> dict[s
     return serialize_object_description(desc)
 
 
-@_safe_tool
+@safe_tool
 def search_schema(query: str, version: str | None = None, limit: int = 50) -> dict[str, Any]:
     """Search for EnergyPlus object types by name or description.
+
+    Use this to find the right object type when you know a keyword but not the exact name.
 
     Args:
         query: Search string (case-insensitive substring match).
@@ -133,7 +117,7 @@ def search_schema(query: str, version: str | None = None, limit: int = 50) -> di
     return {"query": query, "count": len(matches), "limit": limit, "matches": matches}
 
 
-@_safe_tool
+@safe_tool
 def get_available_references(object_type: str, field_name: str) -> dict[str, Any]:
     """Get valid object names for a reference field from the loaded model.
 
@@ -171,3 +155,18 @@ def get_available_references(object_type: str, field_name: str) -> dict[str, Any
         "available_names": all_names,
         "by_reference_list": available,
     }
+
+
+# Annotations are defined after functions to avoid forward-reference errors.
+_TOOL_REGISTRY = [
+    (list_object_types, _READ_ONLY),
+    (describe_object_type, _READ_ONLY),
+    (search_schema, _READ_ONLY),
+    (get_available_references, _READ_ONLY),
+]
+
+
+def register(mcp: FastMCP) -> None:
+    """Register schema tools on the MCP server."""
+    for func, hints in _TOOL_REGISTRY:
+        mcp.tool(annotations=hints)(func)

--- a/src/idfkit_mcp/tools/simulation.py
+++ b/src/idfkit_mcp/tools/simulation.py
@@ -2,39 +2,23 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
-from functools import wraps
 from typing import Any, Literal
 
 from mcp.server.fastmcp import FastMCP
+from mcp.types import ToolAnnotations
 
-from idfkit_mcp.errors import format_error
+from idfkit_mcp.errors import safe_tool
 from idfkit_mcp.state import get_state
 
+_READ_ONLY = ToolAnnotations(readOnlyHint=True, destructiveHint=False, idempotentHint=True, openWorldHint=False)
+_RUN = ToolAnnotations(readOnlyHint=False, destructiveHint=False, idempotentHint=False, openWorldHint=True)
+_EXPORT = ToolAnnotations(readOnlyHint=False, destructiveHint=False, idempotentHint=True, openWorldHint=False)
 
-def _safe_tool(func: Callable[..., dict[str, Any]]) -> Callable[..., dict[str, Any]]:
-    """Convert exceptions into MCP-friendly error dicts."""
-
-    @wraps(func)
-    def wrapper(*args: Any, **kwargs: Any) -> dict[str, Any]:
-        try:
-            return func(*args, **kwargs)
-        except Exception as e:
-            return format_error(e)
-
-    return wrapper
+# Valid EnergyPlus reporting frequencies for time series queries.
+ReportingFrequency = Literal["Timestep", "Hourly", "Daily", "Monthly", "RunPeriod", "Annual"]
 
 
-def register(mcp: FastMCP) -> None:
-    """Register simulation tools on the MCP server."""
-    mcp.tool()(run_simulation)
-    mcp.tool()(get_results_summary)
-    mcp.tool()(list_output_variables)
-    mcp.tool()(query_timeseries)
-    mcp.tool()(export_timeseries)
-
-
-@_safe_tool
+@safe_tool
 def run_simulation(
     weather_file: str | None = None,
     design_day: bool = False,
@@ -43,7 +27,9 @@ def run_simulation(
     energyplus_version: str | None = None,
     output_directory: str | None = None,
 ) -> dict[str, Any]:
-    """Run an EnergyPlus simulation on the loaded model.
+    """Execute an EnergyPlus simulation on the loaded model.
+
+    Use this to run the simulation after building or modifying a model.
 
     Args:
         weather_file: Path to EPW weather file. Uses previously downloaded file if None.
@@ -114,11 +100,11 @@ def run_simulation(
     }
 
 
-@_safe_tool
+@safe_tool
 def get_results_summary() -> dict[str, Any]:
     """Get a summary of the last simulation results.
 
-    Returns energy metrics, error counts, and key tables from the HTML output.
+    Use this after run_simulation to review energy metrics, error counts, and key tables.
     """
     state = get_state()
     result = state.require_simulation_result()
@@ -161,9 +147,11 @@ def get_results_summary() -> dict[str, Any]:
     return summary
 
 
-@_safe_tool
+@safe_tool
 def list_output_variables(search: str | None = None, limit: int = 50) -> dict[str, Any]:
     """List available output variables from the last simulation.
+
+    Use this to discover what time series data is available for querying.
 
     Args:
         search: Optional regex pattern to filter variables by name.
@@ -195,22 +183,23 @@ def list_output_variables(search: str | None = None, limit: int = 50) -> dict[st
     return {"total_available": total, "returned": len(serialized), "variables": serialized}
 
 
-@_safe_tool
+@safe_tool
 def query_timeseries(
     variable_name: str,
     key_value: str = "*",
-    frequency: str | None = None,
+    frequency: ReportingFrequency | None = None,
     environment: Literal["sizing", "annual"] | None = None,
     limit: int = 24,
 ) -> dict[str, Any]:
     """Query time series data from the last simulation's SQL output.
 
-    Returns the first `limit` data points inline for quick inspection.
+    Use this for quick inspection of simulation output data inline.
+    Returns the first `limit` data points.
 
     Args:
         variable_name: The output variable name (e.g. "Zone Mean Air Temperature").
         key_value: Key value such as zone or surface name. Use "*" for environment-level variables.
-        frequency: Optional frequency filter (e.g. "Hourly").
+        frequency: Reporting frequency filter (e.g. "Hourly", "Monthly").
         environment: Filter by environment type: "sizing" or "annual".
         limit: Maximum number of data points to return (default 24).
     """
@@ -243,20 +232,22 @@ def query_timeseries(
     }
 
 
-@_safe_tool
+@safe_tool
 def export_timeseries(
     variable_name: str,
     key_value: str = "*",
-    frequency: str | None = None,
+    frequency: ReportingFrequency | None = None,
     environment: Literal["sizing", "annual"] | None = None,
     output_path: str | None = None,
 ) -> dict[str, Any]:
     """Export time series data from the last simulation to a CSV file.
 
+    Use this to save full simulation output data for external analysis.
+
     Args:
         variable_name: The output variable name (e.g. "Zone Mean Air Temperature").
         key_value: Key value such as zone or surface name. Use "*" for environment-level variables.
-        frequency: Optional frequency filter (e.g. "Hourly").
+        frequency: Reporting frequency filter (e.g. "Hourly", "Monthly").
         environment: Filter by environment type: "sizing" or "annual".
         output_path: Output CSV file path. Defaults to a file in the simulation output directory.
     """
@@ -298,3 +289,19 @@ def export_timeseries(
         "frequency": ts.frequency,
         "rows": len(ts.values),
     }
+
+
+# Annotations are defined after functions to avoid forward-reference errors.
+_TOOL_REGISTRY = [
+    (run_simulation, _RUN),
+    (get_results_summary, _READ_ONLY),
+    (list_output_variables, _READ_ONLY),
+    (query_timeseries, _READ_ONLY),
+    (export_timeseries, _EXPORT),
+]
+
+
+def register(mcp: FastMCP) -> None:
+    """Register simulation tools on the MCP server."""
+    for func, hints in _TOOL_REGISTRY:
+        mcp.tool(annotations=hints)(func)

--- a/src/idfkit_mcp/tools/validation.py
+++ b/src/idfkit_mcp/tools/validation.py
@@ -2,39 +2,23 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
-from functools import wraps
 from typing import Any
 
 from mcp.server.fastmcp import FastMCP
+from mcp.types import ToolAnnotations
 
-from idfkit_mcp.errors import format_error
+from idfkit_mcp.errors import safe_tool
 from idfkit_mcp.serializers import serialize_validation_result
 from idfkit_mcp.state import get_state
 
-
-def _safe_tool(func: Callable[..., dict[str, Any]]) -> Callable[..., dict[str, Any]]:
-    """Convert exceptions into MCP-friendly error dicts."""
-
-    @wraps(func)
-    def wrapper(*args: Any, **kwargs: Any) -> dict[str, Any]:
-        try:
-            return func(*args, **kwargs)
-        except Exception as e:
-            return format_error(e)
-
-    return wrapper
+_READ_ONLY = ToolAnnotations(readOnlyHint=True, destructiveHint=False, idempotentHint=True, openWorldHint=False)
 
 
-def register(mcp: FastMCP) -> None:
-    """Register validation tools on the MCP server."""
-    mcp.tool()(validate_model)
-    mcp.tool()(check_references)
-
-
-@_safe_tool
+@safe_tool
 def validate_model(object_types: list[str] | None = None, check_references: bool = True) -> dict[str, Any]:
     """Validate the loaded model against the EnergyPlus schema.
+
+    Use this after making modifications to check for errors before simulation.
 
     Args:
         object_types: Only validate specific types (default: all).
@@ -48,11 +32,11 @@ def validate_model(object_types: list[str] | None = None, check_references: bool
     return serialize_validation_result(result)
 
 
-@_safe_tool
+@safe_tool
 def check_references() -> dict[str, Any]:
     """Check for dangling references in the loaded model.
 
-    Returns a list of references that point to non-existent objects.
+    Use this to find references that point to non-existent objects.
     """
     state = get_state()
     doc = state.require_model()
@@ -73,3 +57,16 @@ def check_references() -> dict[str, Any]:
         })
 
     return {"dangling_count": len(dangling), "dangling_references": dangling}
+
+
+# Annotations are defined after functions to avoid forward-reference errors.
+_TOOL_REGISTRY = [
+    (validate_model, _READ_ONLY),
+    (check_references, _READ_ONLY),
+]
+
+
+def register(mcp: FastMCP) -> None:
+    """Register validation tools on the MCP server."""
+    for func, hints in _TOOL_REGISTRY:
+        mcp.tool(annotations=hints)(func)

--- a/src/idfkit_mcp/tools/weather.py
+++ b/src/idfkit_mcp/tools/weather.py
@@ -2,37 +2,20 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
-from functools import wraps
 from typing import Any
 
 from mcp.server.fastmcp import FastMCP
+from mcp.types import ToolAnnotations
 
-from idfkit_mcp.errors import format_error
+from idfkit_mcp.errors import safe_tool
 from idfkit_mcp.serializers import serialize_station
 from idfkit_mcp.state import get_state
 
-
-def _safe_tool(func: Callable[..., dict[str, Any]]) -> Callable[..., dict[str, Any]]:
-    """Convert exceptions into MCP-friendly error dicts."""
-
-    @wraps(func)
-    def wrapper(*args: Any, **kwargs: Any) -> dict[str, Any]:
-        try:
-            return func(*args, **kwargs)
-        except Exception as e:
-            return format_error(e)
-
-    return wrapper
+_READ_ONLY_OPEN = ToolAnnotations(readOnlyHint=True, destructiveHint=False, idempotentHint=True, openWorldHint=True)
+_DOWNLOAD = ToolAnnotations(readOnlyHint=False, destructiveHint=False, idempotentHint=True, openWorldHint=True)
 
 
-def register(mcp: FastMCP) -> None:
-    """Register weather tools on the MCP server."""
-    mcp.tool()(search_weather_stations)
-    mcp.tool()(download_weather_file)
-
-
-@_safe_tool
+@safe_tool
 def search_weather_stations(
     query: str | None = None,
     latitude: float | None = None,
@@ -43,7 +26,8 @@ def search_weather_stations(
 ) -> dict[str, Any]:
     """Search for weather stations by name/location or coordinates.
 
-    Provide either a text query or latitude/longitude for spatial search.
+    Use this to find an EPW weather file for simulation. Provide either a text
+    query or latitude/longitude for spatial search.
 
     IMPORTANT: Keep query short (just the city name). Use country/state params
     to disambiguate. For example, use query="Boston", country="USA", state="MA"
@@ -105,7 +89,7 @@ def _matches_filters(station: Any, country: str | None, state: str | None) -> bo
     return not (state and station.state.upper() != state.upper())
 
 
-@_safe_tool
+@safe_tool
 def download_weather_file(
     wmo: str | None = None,
     query: str | None = None,
@@ -114,7 +98,8 @@ def download_weather_file(
 ) -> dict[str, Any]:
     """Download an EPW weather file for simulation.
 
-    The downloaded file path is stored for reuse with run_simulation.
+    Use this to get a weather file before running a simulation. The downloaded
+    file path is stored for reuse with run_simulation.
 
     IMPORTANT: Keep query short (just the city name). Use country/state params
     to disambiguate. For example, use query="Boston", country="USA", state="MA"
@@ -164,3 +149,16 @@ def download_weather_file(
         "epw_path": str(files.epw),
         "ddy_path": str(files.ddy),
     }
+
+
+# Annotations are defined after functions to avoid forward-reference errors.
+_TOOL_REGISTRY = [
+    (search_weather_stations, _READ_ONLY_OPEN),
+    (download_weather_file, _DOWNLOAD),
+]
+
+
+def register(mcp: FastMCP) -> None:
+    """Register weather tools on the MCP server."""
+    for func, hints in _TOOL_REGISTRY:
+        mcp.tool(annotations=hints)(func)

--- a/src/idfkit_mcp/tools/write.py
+++ b/src/idfkit_mcp/tools/write.py
@@ -2,45 +2,25 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
-from functools import wraps
-from typing import Any
+from typing import Any, Literal
 
 from mcp.server.fastmcp import FastMCP
+from mcp.types import ToolAnnotations
 
-from idfkit_mcp.errors import format_error
+from idfkit_mcp.errors import safe_tool
 from idfkit_mcp.serializers import serialize_object
 from idfkit_mcp.state import get_state
 
-
-def _safe_tool(func: Callable[..., dict[str, Any]]) -> Callable[..., dict[str, Any]]:
-    """Convert exceptions into MCP-friendly error dicts."""
-
-    @wraps(func)
-    def wrapper(*args: Any, **kwargs: Any) -> dict[str, Any]:
-        try:
-            return func(*args, **kwargs)
-        except Exception as e:
-            return format_error(e)
-
-    return wrapper
+_MUTATE = ToolAnnotations(readOnlyHint=False, destructiveHint=False, idempotentHint=False, openWorldHint=False)
+_DESTRUCTIVE = ToolAnnotations(readOnlyHint=False, destructiveHint=True, idempotentHint=False, openWorldHint=False)
+_SAVE = ToolAnnotations(readOnlyHint=False, destructiveHint=False, idempotentHint=True, openWorldHint=False)
 
 
-def register(mcp: FastMCP) -> None:
-    """Register write tools on the MCP server."""
-    mcp.tool()(new_model)
-    mcp.tool()(add_object)
-    mcp.tool()(batch_add_objects)
-    mcp.tool()(update_object)
-    mcp.tool()(remove_object)
-    mcp.tool()(rename_object)
-    mcp.tool()(duplicate_object)
-    mcp.tool()(save_model)
-
-
-@_safe_tool
+@safe_tool
 def new_model(version: str | None = None) -> dict[str, Any]:
     """Create a new empty EnergyPlus model.
+
+    Use this to start building a model from scratch.
 
     Args:
         version: EnergyPlus version as "X.Y.Z" (default: latest).
@@ -62,11 +42,12 @@ def new_model(version: str | None = None) -> dict[str, Any]:
     return {"status": "created", "version": version_string(ver)}
 
 
-@_safe_tool
+@safe_tool
 def add_object(object_type: str, name: str = "", fields: dict[str, Any] | None = None) -> dict[str, Any]:
     """Add a new object to the model.
 
-    Call describe_object_type first to see valid fields for this type.
+    Use this to create a single EnergyPlus object. Call describe_object_type first
+    to see valid fields for this type.
 
     Args:
         object_type: The EnergyPlus object type (e.g. "Zone", "Material").
@@ -80,13 +61,14 @@ def add_object(object_type: str, name: str = "", fields: dict[str, Any] | None =
     return serialize_object(obj)
 
 
-@_safe_tool
+@safe_tool
 def batch_add_objects(objects: list[dict[str, Any]]) -> dict[str, Any]:
     """Add multiple objects to the model in a single call.
 
-    Critical for efficiency — creating a building zone-by-zone requires many objects.
-    Each entry should have: object_type (required), name (optional), fields (optional).
-    Continues on individual failures and reports per-object results.
+    Use this when creating multiple objects at once for efficiency — building a zone
+    requires many related objects. Each entry should have: object_type (required),
+    name (optional), fields (optional). Continues on individual failures and reports
+    per-object results.
 
     Args:
         objects: List of dicts with keys: object_type, name, fields.
@@ -118,9 +100,11 @@ def batch_add_objects(objects: list[dict[str, Any]]) -> dict[str, Any]:
     return {"total": len(objects), "success": success_count, "errors": error_count, "results": results}
 
 
-@_safe_tool
+@safe_tool
 def update_object(object_type: str, name: str, fields: dict[str, Any]) -> dict[str, Any]:
     """Update fields on an existing object.
+
+    Use this to modify field values on an object already in the model.
 
     Args:
         object_type: The EnergyPlus object type.
@@ -143,12 +127,12 @@ def update_object(object_type: str, name: str, fields: dict[str, Any]) -> dict[s
     return serialize_object(obj)
 
 
-@_safe_tool
+@safe_tool
 def remove_object(object_type: str, name: str, force: bool = False) -> dict[str, Any]:
     """Remove an object from the model.
 
-    By default, refuses removal if other objects reference this one.
-    Use force=True to remove anyway.
+    Use this to delete an object. Refuses removal if other objects reference it
+    unless force=True.
 
     Args:
         object_type: The EnergyPlus object type.
@@ -178,9 +162,11 @@ def remove_object(object_type: str, name: str, force: bool = False) -> dict[str,
     return {"status": "removed", "object_type": object_type, "name": name}
 
 
-@_safe_tool
+@safe_tool
 def rename_object(object_type: str, old_name: str, new_name: str) -> dict[str, Any]:
     """Rename an object and update all references to it.
+
+    Use this to change an object's name while keeping the model consistent.
 
     Args:
         object_type: The EnergyPlus object type.
@@ -204,9 +190,11 @@ def rename_object(object_type: str, old_name: str, new_name: str) -> dict[str, A
     }
 
 
-@_safe_tool
+@safe_tool
 def duplicate_object(object_type: str, name: str, new_name: str) -> dict[str, Any]:
     """Duplicate an existing object with a new name.
+
+    Use this to copy an object as a starting point for a similar one.
 
     Args:
         object_type: The EnergyPlus object type.
@@ -220,9 +208,11 @@ def duplicate_object(object_type: str, name: str, new_name: str) -> dict[str, An
     return serialize_object(obj)
 
 
-@_safe_tool
-def save_model(file_path: str | None = None, output_format: str = "idf") -> dict[str, Any]:
+@safe_tool
+def save_model(file_path: str | None = None, output_format: Literal["idf", "epjson"] = "idf") -> dict[str, Any]:
     """Save the model to a file.
+
+    Use this to persist changes to disk in IDF or epJSON format.
 
     Args:
         file_path: Output path. If None, uses the original load path.
@@ -242,10 +232,29 @@ def save_model(file_path: str | None = None, output_format: str = "idf") -> dict
     else:
         return {"error": "No file path specified and no original path available."}
 
-    if output_format.lower() == "epjson":
+    if output_format == "epjson":
         write_epjson(doc, path)
     else:
         write_idf(doc, path)
 
     state.file_path = path
     return {"status": "saved", "file_path": str(path), "format": output_format}
+
+
+# Annotations are defined after functions to avoid forward-reference errors.
+_TOOL_REGISTRY = [
+    (new_model, _MUTATE),
+    (add_object, _MUTATE),
+    (batch_add_objects, _MUTATE),
+    (update_object, _MUTATE),
+    (remove_object, _DESTRUCTIVE),
+    (rename_object, _MUTATE),
+    (duplicate_object, _MUTATE),
+    (save_model, _SAVE),
+]
+
+
+def register(mcp: FastMCP) -> None:
+    """Register write tools on the MCP server."""
+    for func, hints in _TOOL_REGISTRY:
+        mcp.tool(annotations=hints)(func)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 import pytest
 
 from idfkit_mcp.server import _parse_args, create_server
@@ -100,3 +102,52 @@ class TestParseArgs:
     def test_invalid_transport_rejected(self) -> None:
         with pytest.raises(SystemExit):
             _parse_args(["--transport", "invalid"])
+
+
+class TestToolSchemas:
+    """Verify that all tool schemas are well-formed for broad client compatibility."""
+
+    @pytest.fixture()
+    def tools(self) -> dict[str, Any]:
+        server = create_server()
+        return server._tool_manager._tools
+
+    def test_all_tools_have_properties_key(self, tools: dict[str, Any]) -> None:
+        """Every tool's inputSchema must include a 'properties' key.
+
+        OpenAI's Agents SDK and other strict consumers require this key to be
+        present, even for tools with no parameters (where it should be ``{}``).
+        """
+        for name, tool in tools.items():
+            schema = tool.parameters
+            assert "properties" in schema, f"Tool '{name}' inputSchema missing 'properties' key: {schema}"
+
+    def test_all_tools_have_annotations(self, tools: dict[str, Any]) -> None:
+        """Every tool should have ToolAnnotations set (readOnlyHint, etc.)."""
+        for name, tool in tools.items():
+            assert tool.annotations is not None, f"Tool '{name}' is missing annotations"
+
+    def test_schemas_support_additional_properties_false(self, tools: dict[str, Any]) -> None:
+        """Verify schemas can accept additionalProperties: false without conflict.
+
+        OpenAI's ``convert_schemas_to_strict`` applies this constraint. Tools
+        using open-ended ``dict[str, Any]`` parameters (e.g. add_object.fields,
+        batch_add_objects.objects) are exempt since EnergyPlus field names are
+        inherently dynamic.
+        """
+        # Tools with intentionally dynamic dict parameters that cannot be
+        # constrained to a static schema.
+        dynamic_schema_tools = {"add_object", "batch_add_objects", "update_object"}
+
+        for name, tool in tools.items():
+            if name in dynamic_schema_tools:
+                continue
+            schema = tool.parameters
+            properties = schema.get("properties", {})
+            for prop_name, prop_schema in properties.items():
+                # Nested object schemas should not conflict with additionalProperties: false
+                if prop_schema.get("type") == "object" and "properties" not in prop_schema:
+                    pytest.fail(
+                        f"Tool '{name}' param '{prop_name}' is an unstructured object "
+                        f"(no 'properties' key) — incompatible with strict mode."
+                    )


### PR DESCRIPTION
## Summary
- Consolidate 6 duplicated `_safe_tool` decorators into a single `safe_tool` in `errors.py`
- Add `ToolAnnotations` (`readOnlyHint`, `destructiveHint`, `idempotentHint`, `openWorldHint`) to all 27 MCP tools
- Improve tool docstrings with "Use this to..." prefixes for better LLM tool selection
- Add `Literal` types for `save_model(output_format)` and timeseries `frequency` params
- Add schema validation tests: `properties` key presence, annotation completeness, strict-mode compatibility
- Document multi-session state limitation for HTTP transports in `ServerState`
- Document `structuredContent` as future work in `create_server()`

## Test plan
- [x] `make check` passes (ruff lint/format, pyright strict, deptry)
- [x] `make test` passes (92/92 tests, including 3 new schema validation tests)
- [x] Rebased cleanly on latest `main` (merged upstream `limit`/truncation changes in `schema.py` and `weather.py` caching)

🤖 Generated with [Claude Code](https://claude.com/claude-code)