### PR TITLE
Fix OSM stdout corruption and SQL query error handling

### DIFF
--- a/src/idfkit_mcp/tools/read.py
+++ b/src/idfkit_mcp/tools/read.py
@@ -106,19 +106,30 @@ def convert_osm_to_idf(
     if not out_path.parent.exists():
         raise ToolError(f"Output directory does not exist: '{out_path.parent}'.")
 
-    version_translator = openstudio.osversion.VersionTranslator()
-    version_translator.setAllowNewerVersions(allow_newer_versions)
-    optional_model = version_translator.loadModel(openstudio.path(str(input_path)))
-    if optional_model.empty():
-        raise ToolError(f"Failed to load OSM model: '{input_path}'.")
+    # OpenStudio's C++ ForwardTranslator writes warnings directly to fd 1
+    # (C-level stdout), which corrupts the MCP stdio JSON-RPC stream.
+    # Redirect fd 1 → fd 2 (stderr) during translation to keep the transport clean.
+    import os
 
-    model = optional_model.get()
-    forward_translator = openstudio.energyplus.ForwardTranslator()
-    workspace = forward_translator.translateModel(model)
+    saved_fd = os.dup(1)
+    os.dup2(2, 1)
+    try:
+        version_translator = openstudio.osversion.VersionTranslator()
+        version_translator.setAllowNewerVersions(allow_newer_versions)
+        optional_model = version_translator.loadModel(openstudio.path(str(input_path)))
+        if optional_model.empty():
+            raise ToolError(f"Failed to load OSM model: '{input_path}'.")
 
-    saved = workspace.save(openstudio.path(str(out_path)), overwrite)
-    if not saved:
-        raise ToolError(f"Failed to save translated IDF to '{out_path}'.")
+        model = optional_model.get()
+        forward_translator = openstudio.energyplus.ForwardTranslator()
+        workspace = forward_translator.translateModel(model)
+
+        saved = workspace.save(openstudio.path(str(out_path)), overwrite)
+        if not saved:
+            raise ToolError(f"Failed to save translated IDF to '{out_path}'.")
+    finally:
+        os.dup2(saved_fd, 1)
+        os.close(saved_fd)
 
     doc = load_idf(str(out_path))
     state = get_state()

--- a/src/idfkit_mcp/tools/simulation.py
+++ b/src/idfkit_mcp/tools/simulation.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from sqlite3 import OperationalError
 from typing import Any, Literal
 
 from mcp.server.fastmcp import FastMCP
@@ -223,12 +224,19 @@ def query_timeseries(
     if sql is None:
         raise ToolError("No SQL output available. The simulation may not have produced an .sql file.")
 
-    ts = sql.get_timeseries(
-        variable_name=variable_name,
-        key_value=key_value,
-        frequency=frequency,
-        environment=environment,
-    )
+    try:
+        ts = sql.get_timeseries(
+            variable_name=variable_name,
+            key_value=key_value,
+            frequency=frequency,
+            environment=environment,
+        )
+    except OperationalError as e:
+        raise ToolError(
+            f"SQL query failed: {e}. "
+            "The simulation may not have completed successfully, or Output:SQLite was not configured in the model. "
+            "Check run_simulation results for errors."
+        ) from e
 
     rows = [
         {"timestamp": ts.timestamps[i].isoformat(), "value": ts.values[i]} for i in range(min(limit, len(ts.values)))
@@ -275,12 +283,19 @@ def export_timeseries(
     if sql is None:
         raise ToolError("No SQL output available. The simulation may not have produced an .sql file.")
 
-    ts = sql.get_timeseries(
-        variable_name=variable_name,
-        key_value=key_value,
-        frequency=frequency,
-        environment=environment,
-    )
+    try:
+        ts = sql.get_timeseries(
+            variable_name=variable_name,
+            key_value=key_value,
+            frequency=frequency,
+            environment=environment,
+        )
+    except OperationalError as e:
+        raise ToolError(
+            f"SQL query failed: {e}. "
+            "The simulation may not have completed successfully, or Output:SQLite was not configured in the model. "
+            "Check run_simulation results for errors."
+        ) from e
 
     if output_path is not None:
         csv_path = Path(output_path)


### PR DESCRIPTION
## Summary
- Redirect fd 1→fd 2 during OpenStudio ForwardTranslator to prevent C++ stdout writes from corrupting the MCP stdio JSON-RPC stream
- Catch `sqlite3.OperationalError` in `query_timeseries` and `export_timeseries` with descriptive error messages

## Test plan
- [x] Existing tests pass (`make check && make test`)
- [ ] Manual: run `convert_osm_to_idf` over stdio transport and verify no stream corruption
- [ ] Manual: call `query_timeseries` on a simulation without SQL output and verify the error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)