### PR TITLE
Add session persistence across server restarts

### DIFF
--- a/src/idfkit_mcp/models.py
+++ b/src/idfkit_mcp/models.py
@@ -424,3 +424,14 @@ class DownloadWeatherFileResult(BaseModel):
     station: WeatherStationModel
     epw_path: str
     ddy_path: str
+
+
+# ---------------------------------------------------------------------------
+# Session management
+# ---------------------------------------------------------------------------
+
+
+class ClearSessionResult(BaseModel):
+    """Response from ``clear_session``."""
+
+    status: str

--- a/src/idfkit_mcp/state.py
+++ b/src/idfkit_mcp/state.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+import dataclasses
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from idfkit import LATEST_VERSION, get_schema
 
@@ -15,11 +15,65 @@ if TYPE_CHECKING:
     from idfkit.weather.index import StationIndex
 
 
-@dataclass
+def _cache_base_dir() -> Path:
+    """Return the platform-appropriate idfkit cache base directory."""
+    import os
+    import sys
+
+    if sys.platform == "win32":
+        base = Path(os.environ.get("LOCALAPPDATA", Path.home() / "AppData" / "Local"))
+        return base / "idfkit" / "cache"
+    if sys.platform == "darwin":
+        return Path.home() / "Library" / "Caches" / "idfkit"
+    # Linux / other POSIX
+    xdg = os.environ.get("XDG_CACHE_HOME")
+    base = Path(xdg) if xdg else Path.home() / ".cache"
+    return base / "idfkit"
+
+
+def _session_cache_dir() -> Path:
+    """Return the platform-appropriate directory for session state files."""
+    return _cache_base_dir() / "sessions"
+
+
+def _session_file_path() -> Path:
+    """Return the session file path, keyed by a hash of the current working directory."""
+    import hashlib
+
+    cwd = str(Path.cwd().resolve())
+    cwd_hash = hashlib.sha256(cwd.encode()).hexdigest()[:12]
+    return _session_cache_dir() / f"{cwd_hash}.json"
+
+
+def _read_session_file() -> dict[str, Any] | None:
+    """Read and validate the session file, returning None on any failure."""
+    import json
+    import logging
+
+    session_path = _session_file_path()
+    if not session_path.exists():
+        return None
+
+    try:
+        data: dict[str, Any] = json.loads(session_path.read_text())
+    except (json.JSONDecodeError, OSError):
+        logging.getLogger(__name__).warning("Corrupt session file, ignoring: %s", session_path)
+        return None
+
+    if data.get("version") != 1:
+        return None
+    return data
+
+
+@dataclasses.dataclass
 class ServerState:
     """Holds the active document, schema, and simulation result.
 
     MCP stdio transport is single-threaded, so a module-level instance is safe.
+
+    Session state (file_path, simulation run dir, weather file) is persisted
+    to a JSON file on disk so that clients that restart the server between
+    turns (e.g. Codex) can transparently resume where they left off.
 
     WARNING: For streamable-http or SSE transports with multiple concurrent
     clients, this singleton will cause cross-session state contamination.
@@ -34,15 +88,23 @@ class ServerState:
     weather_file: Path | None = None
     station_index: StationIndex | None = None
 
+    # Session persistence control
+    persistence_enabled: bool = True
+    _session_restored: bool = dataclasses.field(default=False, repr=False)
+
     def require_model(self) -> IDFDocument:
-        """Return the active document or raise a descriptive error."""
+        """Return the active document, auto-restoring from session if needed."""
+        if self.document is None:
+            self._try_restore_session()
         if self.document is None:
             msg = "No model loaded. Use load_model or new_model first."
             raise RuntimeError(msg)
         return self.document
 
     def require_schema(self) -> EpJSONSchema:
-        """Return the active schema or raise a descriptive error."""
+        """Return the active schema, auto-restoring from session if needed."""
+        if self.schema is None:
+            self._try_restore_session()
         if self.schema is None:
             msg = "No schema loaded. Use load_model or new_model first."
             raise RuntimeError(msg)
@@ -65,11 +127,124 @@ class ServerState:
         return self.station_index
 
     def require_simulation_result(self) -> SimulationResult:
-        """Return the simulation result or raise a descriptive error."""
+        """Return the simulation result, auto-restoring from session if needed."""
+        if self.simulation_result is None:
+            self._try_restore_session()
         if self.simulation_result is None:
             msg = "No simulation results available. Use run_simulation first."
             raise RuntimeError(msg)
         return self.simulation_result
+
+    # ------------------------------------------------------------------
+    # Session persistence
+    # ------------------------------------------------------------------
+
+    def save_session(self) -> None:
+        """Persist restorable state paths to the session file."""
+        if not self.persistence_enabled:
+            return
+
+        import json
+        from datetime import datetime, timezone
+
+        data: dict[str, Any] = {
+            "version": 1,
+            "cwd": str(Path.cwd().resolve()),
+            "updated_at": datetime.now(timezone.utc).isoformat(),
+        }
+        if self.file_path is not None and self.file_path.exists():
+            data["file_path"] = str(self.file_path.resolve())
+        if self.simulation_result is not None and self.simulation_result.run_dir.is_dir():
+            data["simulation_run_dir"] = str(self.simulation_result.run_dir.resolve())
+        if self.weather_file is not None and self.weather_file.exists():
+            data["weather_file"] = str(self.weather_file.resolve())
+
+        import logging
+
+        session_path = _session_file_path()
+        try:
+            session_path.parent.mkdir(parents=True, exist_ok=True)
+            session_path.write_text(json.dumps(data, indent=2))
+        except OSError:
+            logging.getLogger(__name__).warning("Failed to write session file: %s", session_path, exc_info=True)
+
+    def _try_restore_session(self) -> None:
+        """Attempt to restore state from the session file (called once lazily)."""
+        if self._session_restored or not self.persistence_enabled:
+            return
+        self._session_restored = True
+
+        data = _read_session_file()
+        if data is None:
+            return
+
+        self._restore_model(data)
+        self._restore_simulation(data)
+        self._restore_weather(data)
+
+    def _restore_model(self, data: dict[str, Any]) -> None:
+        """Restore model from a session data dict."""
+        import logging
+
+        file_path_str = data.get("file_path")
+        if file_path_str is None or self.document is not None:
+            return
+        fp = Path(file_path_str)
+        if not fp.exists():
+            return
+        try:
+            from idfkit import load_epjson, load_idf
+
+            doc = load_epjson(str(fp)) if fp.suffix.lower() in (".epjson", ".json") else load_idf(str(fp))
+            self.document = doc
+            self.schema = doc.schema
+            self.file_path = fp
+            logging.getLogger(__name__).info("Restored model from session: %s", fp)
+        except Exception:
+            logging.getLogger(__name__).warning("Failed to restore model from %s", fp, exc_info=True)
+
+    def _restore_simulation(self, data: dict[str, Any]) -> None:
+        """Restore simulation result from a session data dict."""
+        import logging
+
+        run_dir_str = data.get("simulation_run_dir")
+        if run_dir_str is None or self.simulation_result is not None:
+            return
+        rd = Path(run_dir_str)
+        if not rd.is_dir():
+            return
+        try:
+            from idfkit.simulation.result import SimulationResult as SimResult
+
+            self.simulation_result = SimResult.from_directory(rd)
+            logging.getLogger(__name__).info("Restored simulation result from session: %s", rd)
+        except Exception:
+            logging.getLogger(__name__).warning("Failed to restore simulation result from %s", rd, exc_info=True)
+
+    def _restore_weather(self, data: dict[str, Any]) -> None:
+        """Restore weather file path from a session data dict."""
+        import logging
+
+        weather_str = data.get("weather_file")
+        if weather_str is None or self.weather_file is not None:
+            return
+        wp = Path(weather_str)
+        if wp.exists():
+            self.weather_file = wp
+            logging.getLogger(__name__).info("Restored weather file from session: %s", wp)
+
+    def clear_session(self) -> None:
+        """Delete the session file and reset all restorable state."""
+        if self.persistence_enabled:
+            session_path = _session_file_path()
+            if session_path.exists():
+                session_path.unlink()
+        self.document = None
+        self.schema = None
+        self.file_path = None
+        self.simulation_result = None
+        self.weather_file = None
+        self._session_restored = False
 
 
 # Module-level singleton

--- a/src/idfkit_mcp/tools/read.py
+++ b/src/idfkit_mcp/tools/read.py
@@ -55,6 +55,7 @@ def load_model(file_path: str, version: str | None = None) -> ModelSummary:
     state.schema = doc.schema
     state.file_path = path
     state.simulation_result = None
+    state.save_session()
 
     return _build_summary(doc, state)
 
@@ -137,6 +138,7 @@ def convert_osm_to_idf(
     state.schema = doc.schema
     state.file_path = out_path
     state.simulation_result = None
+    state.save_session()
 
     version_getter = getattr(openstudio, "openStudioVersion", None)
     openstudio_version = str(version_getter()) if callable(version_getter) else "unknown"

--- a/src/idfkit_mcp/tools/simulation.py
+++ b/src/idfkit_mcp/tools/simulation.py
@@ -77,6 +77,7 @@ def run_simulation(
     )
 
     state.simulation_result = result
+    state.save_session()
 
     errors = result.errors
 

--- a/src/idfkit_mcp/tools/weather.py
+++ b/src/idfkit_mcp/tools/weather.py
@@ -144,6 +144,7 @@ def download_weather_file(
 
     server_state = get_state()
     server_state.weather_file = files.epw
+    server_state.save_session()
 
     return DownloadWeatherFileResult.model_validate({
         "status": "downloaded",

--- a/src/idfkit_mcp/tools/write.py
+++ b/src/idfkit_mcp/tools/write.py
@@ -12,6 +12,7 @@ from mcp.types import ToolAnnotations
 from idfkit_mcp.errors import safe_tool
 from idfkit_mcp.models import (
     BatchAddResult,
+    ClearSessionResult,
     NewModelResult,
     RemoveObjectResult,
     RenameObjectResult,
@@ -246,7 +247,20 @@ def save_model(file_path: str | None = None, output_format: Literal["idf", "epjs
         write_idf(doc, path)
 
     state.file_path = path
+    state.save_session()
     return SaveModelResult(status="saved", file_path=str(path), format=output_format)
+
+
+@safe_tool
+def clear_session() -> ClearSessionResult:
+    """Clear the persisted session and reset all state.
+
+    Use this to start fresh when the restored model or simulation results are
+    stale or unwanted.  Does not delete any model or simulation files on disk.
+    """
+    state = get_state()
+    state.clear_session()
+    return ClearSessionResult(status="cleared")
 
 
 # ---------------------------------------------------------------------------
@@ -260,6 +274,7 @@ _STRUCTURED_TOOLS = [
     (remove_object, _DESTRUCTIVE),
     (rename_object, _MUTATE),
     (save_model, _SAVE),
+    (clear_session, _DESTRUCTIVE),
 ]
 
 _UNSTRUCTURED_TOOLS = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,6 +18,8 @@ def _reset_state() -> None:
     state.simulation_result = None
     state.weather_file = None
     state.station_index = None
+    state.persistence_enabled = False
+    state._session_restored = False
 
 
 @pytest.fixture()

--- a/tests/test_session_persistence.py
+++ b/tests/test_session_persistence.py
@@ -1,0 +1,286 @@
+"""Tests for session state persistence."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from idfkit import new_document, write_idf
+
+from idfkit_mcp.state import get_state
+
+
+def _tool(name: str):
+    from idfkit_mcp.server import mcp
+
+    return mcp._tool_manager._tools[name]
+
+
+@pytest.fixture()
+def _enable_persistence(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Enable persistence with a temp session file for the test."""
+    session_file = tmp_path / "test_session.json"
+    monkeypatch.setattr("idfkit_mcp.state._session_file_path", lambda: session_file)
+    state = get_state()
+    state.persistence_enabled = True
+    state._session_restored = False
+    return session_file
+
+
+class TestSaveSession:
+    def test_save_and_restore_model(self, _enable_persistence: Path, tmp_path: Path) -> None:
+        session_file = _enable_persistence
+        state = get_state()
+
+        # Create and save a model to disk
+        doc = new_document()
+        doc.add("Zone", "TestZone")
+        idf_path = tmp_path / "test.idf"
+        write_idf(doc, idf_path)
+
+        # Load via the tool (which calls save_session)
+        state.document = doc
+        state.schema = doc.schema
+        state.file_path = idf_path
+        state.save_session()
+
+        assert session_file.exists()
+        data = json.loads(session_file.read_text())
+        assert data["file_path"] == str(idf_path.resolve())
+
+        # Reset state to simulate a new server process
+        state.document = None
+        state.schema = None
+        state.file_path = None
+        state._session_restored = False
+
+        # Restore should bring the model back
+        state._try_restore_session()
+        assert state.document is not None
+        assert state.file_path == idf_path
+        assert "TestZone" in [obj.name for obj in state.document.get_collection("Zone")]
+
+    def test_save_and_restore_weather(self, _enable_persistence: Path, tmp_path: Path) -> None:
+        session_file = _enable_persistence
+        state = get_state()
+
+        weather_path = tmp_path / "test.epw"
+        weather_path.write_text("LOCATION,Test")
+        state.weather_file = weather_path
+        state.save_session()
+
+        data = json.loads(session_file.read_text())
+        assert data["weather_file"] == str(weather_path.resolve())
+
+        state.weather_file = None
+        state._session_restored = False
+        state._try_restore_session()
+        assert state.weather_file == weather_path
+
+    def test_save_and_restore_simulation(self, _enable_persistence: Path, tmp_path: Path) -> None:
+        session_file = _enable_persistence
+        state = get_state()
+
+        # Create a fake simulation output directory with an .err file
+        run_dir = tmp_path / "sim_output"
+        run_dir.mkdir()
+        (run_dir / "eplus.err").write_text("Program Version,EnergyPlus, 25.2.0\nEnergyPlus Completed Successfully.")
+
+        from idfkit.simulation.result import SimulationResult
+
+        state.simulation_result = SimulationResult.from_directory(run_dir)
+        state.save_session()
+
+        data = json.loads(session_file.read_text())
+        assert data["simulation_run_dir"] == str(run_dir.resolve())
+
+        state.simulation_result = None
+        state._session_restored = False
+        state._try_restore_session()
+        assert state.simulation_result is not None
+        assert state.simulation_result.run_dir == run_dir
+
+
+class TestRestoreEdgeCases:
+    def test_missing_file_skipped(self, _enable_persistence: Path, tmp_path: Path) -> None:
+        session_file = _enable_persistence
+        state = get_state()
+
+        idf_path = tmp_path / "gone.idf"
+        # Write session pointing to a file that doesn't exist
+        session_file.write_text(
+            json.dumps({
+                "version": 1,
+                "cwd": str(tmp_path),
+                "file_path": str(idf_path),
+                "updated_at": "2026-01-01T00:00:00+00:00",
+            })
+        )
+
+        state._try_restore_session()
+        assert state.document is None
+        assert state.file_path is None
+
+    def test_corrupt_session_file(self, _enable_persistence: Path) -> None:
+        session_file = _enable_persistence
+        session_file.write_text("not valid json {{{")
+
+        state = get_state()
+        # Should not raise
+        state._try_restore_session()
+        assert state.document is None
+
+    def test_wrong_version_ignored(self, _enable_persistence: Path) -> None:
+        session_file = _enable_persistence
+        session_file.write_text(json.dumps({"version": 999}))
+
+        state = get_state()
+        state._try_restore_session()
+        assert state.document is None
+
+    def test_restore_called_once(self, _enable_persistence: Path) -> None:
+        """_session_restored flag prevents repeated file reads."""
+        session_file = _enable_persistence
+        state = get_state()
+
+        state._try_restore_session()
+        assert state._session_restored is True
+
+        # Write a session file AFTER the first restore
+        session_file.write_text(
+            json.dumps({
+                "version": 1,
+                "cwd": str(session_file.parent),
+                "updated_at": "2026-01-01T00:00:00+00:00",
+            })
+        )
+
+        # Second call should be a no-op (flag is set)
+        state._try_restore_session()
+        # If it re-read, it would have parsed the file — but since it's
+        # a no-op, the state stays the same
+        assert state.document is None
+
+
+class TestSaveSessionFailure:
+    def test_write_failure_does_not_raise(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Point to a path inside a read-only directory
+        readonly_dir = tmp_path / "readonly"
+        readonly_dir.mkdir()
+        readonly_dir.chmod(0o444)
+        bad_path = readonly_dir / "session.json"
+        monkeypatch.setattr("idfkit_mcp.state._session_file_path", lambda: bad_path)
+
+        state = get_state()
+        state.persistence_enabled = True
+        state.file_path = tmp_path / "test.idf"
+        (tmp_path / "test.idf").write_text("Version,25.2;")
+
+        # Should not raise despite permission error
+        state.save_session()
+
+        # Cleanup: restore permissions so tmp_path can be deleted
+        readonly_dir.chmod(0o755)
+        assert not bad_path.exists()
+
+
+class TestPersistenceDisabled:
+    def test_save_is_noop_when_disabled(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        session_file = tmp_path / "should_not_exist.json"
+        monkeypatch.setattr("idfkit_mcp.state._session_file_path", lambda: session_file)
+        state = get_state()
+        # persistence_enabled is False (set by conftest)
+        assert state.persistence_enabled is False
+
+        state.file_path = tmp_path / "test.idf"
+        state.save_session()
+        assert not session_file.exists()
+
+    def test_restore_is_noop_when_disabled(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        session_file = tmp_path / "session.json"
+        session_file.write_text(
+            json.dumps({"version": 1, "cwd": str(tmp_path), "updated_at": "2026-01-01T00:00:00+00:00"})
+        )
+        monkeypatch.setattr("idfkit_mcp.state._session_file_path", lambda: session_file)
+
+        state = get_state()
+        state._session_restored = False
+        # persistence_enabled is False
+        state._try_restore_session()
+        assert state._session_restored is False  # Never even set the flag
+
+
+class TestClearSession:
+    def test_clear_deletes_file_and_resets(self, _enable_persistence: Path, tmp_path: Path) -> None:
+        session_file = _enable_persistence
+        state = get_state()
+
+        doc = new_document()
+        idf_path = tmp_path / "model.idf"
+        write_idf(doc, idf_path)
+        state.document = doc
+        state.schema = doc.schema
+        state.file_path = idf_path
+        state.save_session()
+        assert session_file.exists()
+
+        state.clear_session()
+        assert not session_file.exists()
+        assert state.document is None
+        assert state.file_path is None
+        assert state.simulation_result is None
+        assert state.weather_file is None
+
+
+class TestRequireAutoRestore:
+    def test_require_model_auto_restores(self, _enable_persistence: Path, tmp_path: Path) -> None:
+        state = get_state()
+
+        doc = new_document()
+        doc.add("Zone", "AutoZone")
+        idf_path = tmp_path / "auto.idf"
+        write_idf(doc, idf_path)
+        state.document = doc
+        state.schema = doc.schema
+        state.file_path = idf_path
+        state.save_session()
+
+        # Simulate new process
+        state.document = None
+        state.schema = None
+        state.file_path = None
+        state._session_restored = False
+
+        # require_model should auto-restore instead of raising
+        restored_doc = state.require_model()
+        assert restored_doc is not None
+        assert "AutoZone" in [obj.name for obj in restored_doc.get_collection("Zone")]
+
+    def test_require_model_raises_without_session(self, _enable_persistence: Path) -> None:
+        """With no session file, require_model still raises."""
+        state = get_state()
+        state.document = None
+        with pytest.raises(RuntimeError, match="No model loaded"):
+            state.require_model()
+
+    def test_require_simulation_raises_without_session(self, _enable_persistence: Path) -> None:
+        state = get_state()
+        state.simulation_result = None
+        with pytest.raises(RuntimeError, match="No simulation results"):
+            state.require_simulation_result()
+
+
+class TestNewModelNoSession:
+    def test_new_model_does_not_persist(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        session_file = tmp_path / "session.json"
+        monkeypatch.setattr("idfkit_mcp.state._session_file_path", lambda: session_file)
+        state = get_state()
+        state.persistence_enabled = True
+        state._session_restored = False
+
+        # new_model sets file_path=None, so save_session writes no file_path
+        _tool("new_model").fn()
+        # Session might be written by a future save_model, but new_model
+        # doesn't call save_session itself, so no file should exist
+        assert not session_file.exists()


### PR DESCRIPTION
## Summary
- Add transparent session persistence so loaded model, simulation results, and weather file survive MCP server restarts (needed for clients like Codex that restart between turns)
- Platform-aware cache directory with session file keyed by working directory hash
- Auto-restore from session on `require_model`/`require_schema`/`require_simulation_result`
- New `clear_session` tool to reset persisted state without deleting files on disk

## Test plan
- [x] `make check && make test` — 109 tests pass
- [x] 15 new tests: save/restore model, simulation, weather; edge cases (corrupt file, missing file, wrong version, persistence disabled); clear_session; auto-restore via require_*
- [ ] Manual: load a model → restart server → verify model is auto-restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)