### PR TITLE
Add singleton object support with resolve_object helper

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 keywords = ["energyplus", "mcp", "idfkit", "building-energy"]
 requires-python = ">=3.10,<4.0"
 dependencies = [
-    "idfkit>=0.6.1",
+    "idfkit>=0.6.2",
     "mcp>=1.2.0",
     "openstudio==3.11.0",
     "pydantic>=2.0.0",

--- a/src/idfkit_mcp/tools/__init__.py
+++ b/src/idfkit_mcp/tools/__init__.py
@@ -1,1 +1,35 @@
 """MCP tool modules for idfkit."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from mcp.server.fastmcp.exceptions import ToolError
+
+
+def resolve_object(doc: Any, object_type: str, name: str) -> Any:
+    """Look up an object by type and name, handling singletons correctly.
+
+    Singleton EnergyPlus object types (e.g. SimulationControl, GlobalGeometryRules)
+    have no name field — their name is always ``""``.  These objects are not indexed
+    by name in ``IDFCollection``, so a regular ``collection.get(name)`` always
+    returns ``None``.  This helper detects singletons via the schema and falls back
+    to ``collection.first()``.
+    """
+    if object_type not in doc:
+        raise ToolError(f"No objects of type '{object_type}' in the model.")
+
+    collection = doc.get_collection(object_type)
+    schema = doc.schema
+
+    # Singleton types have no name field in the schema
+    if schema is not None and not schema.has_name(object_type):
+        obj = collection.first()
+        if obj is None:
+            raise ToolError(f"No '{object_type}' object in the model.")
+        return obj
+
+    obj = collection.get(name)
+    if obj is None:
+        raise ToolError(f"Object '{name}' not found in '{object_type}'.")
+    return obj

--- a/src/idfkit_mcp/tools/read.py
+++ b/src/idfkit_mcp/tools/read.py
@@ -19,6 +19,7 @@ from idfkit_mcp.models import (
 )
 from idfkit_mcp.serializers import serialize_object
 from idfkit_mcp.state import get_state
+from idfkit_mcp.tools import resolve_object
 
 _READ_ONLY = ToolAnnotations(readOnlyHint=True, destructiveHint=False, idempotentHint=True, openWorldHint=False)
 _LOAD = ToolAnnotations(readOnlyHint=False, destructiveHint=False, idempotentHint=True, openWorldHint=False)
@@ -204,15 +205,7 @@ def get_object(object_type: str, name: str) -> dict[str, Any]:
     """
     state = get_state()
     doc = state.require_model()
-
-    if object_type not in doc:
-        raise ToolError(f"No objects of type '{object_type}' in the model.")
-
-    collection = doc.get_collection(object_type)
-    obj = collection.get(name)
-    if obj is None:
-        raise ToolError(f"Object '{name}' not found in '{object_type}'.")
-
+    obj = resolve_object(doc, object_type, name)
     return serialize_object(obj)
 
 

--- a/src/idfkit_mcp/tools/write.py
+++ b/src/idfkit_mcp/tools/write.py
@@ -20,6 +20,7 @@ from idfkit_mcp.models import (
 )
 from idfkit_mcp.serializers import serialize_object
 from idfkit_mcp.state import get_state
+from idfkit_mcp.tools import resolve_object
 
 _MUTATE = ToolAnnotations(readOnlyHint=False, destructiveHint=False, idempotentHint=False, openWorldHint=False)
 _DESTRUCTIVE = ToolAnnotations(readOnlyHint=False, destructiveHint=True, idempotentHint=False, openWorldHint=False)
@@ -123,13 +124,7 @@ def update_object(object_type: str, name: str, fields: dict[str, Any]) -> dict[s
     """
     state = get_state()
     doc = state.require_model()
-
-    if object_type not in doc:
-        raise ToolError(f"No objects of type '{object_type}' in the model.")
-
-    obj = doc.get_collection(object_type).get(name)
-    if obj is None:
-        raise ToolError(f"Object '{name}' not found in '{object_type}'.")
+    obj = resolve_object(doc, object_type, name)
 
     for field_name, value in fields.items():
         setattr(obj, field_name, value)
@@ -151,16 +146,11 @@ def remove_object(object_type: str, name: str, force: bool = False) -> RemoveObj
     """
     state = get_state()
     doc = state.require_model()
-
-    if object_type not in doc:
-        raise ToolError(f"No objects of type '{object_type}' in the model.")
-
-    obj = doc.get_collection(object_type).get(name)
-    if obj is None:
-        raise ToolError(f"Object '{name}' not found in '{object_type}'.")
+    obj = resolve_object(doc, object_type, name)
 
     if not force:
-        referencing = doc.get_referencing(name)
+        ref_name = obj.name or name
+        referencing = doc.get_referencing(ref_name)
         if referencing:
             refs = [{"object_type": r.obj_type, "name": r.name} for r in referencing]
             raise ToolError(
@@ -168,7 +158,7 @@ def remove_object(object_type: str, name: str, force: bool = False) -> RemoveObj
             )
 
     doc.removeidfobject(obj)
-    return RemoveObjectResult(status="removed", object_type=object_type, name=name)
+    return RemoveObjectResult(status="removed", object_type=object_type, name=obj.name)
 
 
 @safe_tool
@@ -212,8 +202,9 @@ def duplicate_object(object_type: str, name: str, new_name: str) -> dict[str, An
     """
     state = get_state()
     doc = state.require_model()
+    source = resolve_object(doc, object_type, name)
 
-    obj = doc.copyidfobject(doc.get_collection(object_type)[name], new_name=new_name)
+    obj = doc.copyidfobject(source, new_name=new_name)
     return serialize_object(obj)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -57,3 +57,17 @@ def state_with_zones() -> ServerState:
         validate=False,
     )
     return state
+
+
+@pytest.fixture()
+def state_with_singletons() -> ServerState:
+    """Return server state with a model containing singleton objects.
+
+    ``new_document()`` already creates default singletons (SimulationControl,
+    GlobalGeometryRules, etc.), so we just use those.
+    """
+    state = get_state()
+    doc = new_document()
+    state.document = doc
+    state.schema = doc.schema
+    return state

--- a/tests/test_read_tools.py
+++ b/tests/test_read_tools.py
@@ -82,6 +82,23 @@ class TestGetObject:
             _tool("get_object").fn(object_type="Zone", name="Nonexistent")
 
 
+class TestGetObjectSingleton:
+    """Singleton types (no name field) should be retrievable."""
+
+    def test_get_singleton_with_empty_name(self, state_with_singletons: ServerState) -> None:
+        result = _tool("get_object").fn(object_type="SimulationControl", name="")
+        assert result["object_type"] == "SimulationControl"
+
+    def test_get_singleton_with_any_name(self, state_with_singletons: ServerState) -> None:
+        # AI clients often pass the type name as the name — should still work
+        result = _tool("get_object").fn(object_type="SimulationControl", name="SimulationControl")
+        assert result["object_type"] == "SimulationControl"
+
+    def test_get_singleton_global_geometry_rules(self, state_with_singletons: ServerState) -> None:
+        result = _tool("get_object").fn(object_type="GlobalGeometryRules", name="")
+        assert result["object_type"] == "GlobalGeometryRules"
+
+
 class TestSearchObjects:
     def test_search_by_name(self, state_with_zones: ServerState) -> None:
         result = _tool("search_objects").fn(query="Office")

--- a/tests/test_write_tools.py
+++ b/tests/test_write_tools.py
@@ -117,6 +117,24 @@ class TestDuplicateObject:
         assert result["name"] == "OfficeClone"
 
 
+class TestUpdateObjectSingleton:
+    """Singleton types should be updatable."""
+
+    def test_update_singleton(self, state_with_singletons: ServerState) -> None:
+        result = _tool("update_object").fn(
+            object_type="SimulationControl", name="", fields={"do_zone_sizing_calculation": "No"}
+        )
+        assert result["object_type"] == "SimulationControl"
+
+
+class TestRemoveObjectSingleton:
+    """Singleton types should be removable."""
+
+    def test_remove_singleton(self, state_with_singletons: ServerState) -> None:
+        result = _tool("remove_object").fn(object_type="GlobalGeometryRules", name="", force=True)
+        assert result.status == "removed"
+
+
 class TestSaveModel:
     def test_save_idf(self, state_with_zones: ServerState) -> None:
         with tempfile.NamedTemporaryFile(suffix=".idf", delete=False) as f:

--- a/uv.lock
+++ b/uv.lock
@@ -498,11 +498,11 @@ wheels = [
 
 [[package]]
 name = "idfkit"
-version = "0.6.1"
+version = "0.6.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/62/a7/b1025c15f60e89f30ddeb91f78f3963c28621abecfbfe3f174c9da08d883/idfkit-0.6.1.tar.gz", hash = "sha256:63d047c74e64017966e6bcf7148d1e458aae6e45832e7384c2a840d88a24f3ab", size = 13155071, upload-time = "2026-03-26T04:08:02.292Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/61/1f/2383865e31a923fc188c7c58708433ed204d4e4de0c4aed86d2b69f6eb5a/idfkit-0.6.2.tar.gz", hash = "sha256:cf903eee4190004b52f1abfa875fa0da73f58f30712d09e6f512c6cd144bf550", size = 13155255, upload-time = "2026-03-26T16:59:14.043Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f3/c1/87aabf799503b99b853504f463fcb381a51c17aef4293f501a8bbc7ebf0a/idfkit-0.6.1-py3-none-any.whl", hash = "sha256:0989da37addcdc338c2c023d72ee76e6d58493a92eb1c2e7af5657fdc2b1c19f", size = 12539440, upload-time = "2026-03-26T04:07:58.283Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/b8/cf713e2eda56ed9f44400d8e7a8175f70b86884569b352436bb9ee8d7cba/idfkit-0.6.2-py3-none-any.whl", hash = "sha256:3a754bd045c7f966cee802538db456ba37028a67092435022ec511377e1d1bfb", size = 12539594, upload-time = "2026-03-26T16:59:16.504Z" },
 ]
 
 [[package]]
@@ -531,7 +531,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "idfkit", specifier = ">=0.6.1" },
+    { name = "idfkit", specifier = ">=0.6.2" },
     { name = "mcp", specifier = ">=1.2.0" },
     { name = "openstudio", specifier = "==3.11.0" },
     { name = "pydantic", specifier = ">=2.0.0" },


### PR DESCRIPTION
## Summary
- Extract `resolve_object()` helper into `tools/__init__.py` to handle EnergyPlus singleton types (SimulationControl, GlobalGeometryRules, etc.) that have no name field
- Apply it to `get_object`, `update_object`, `remove_object`, and `duplicate_object` — these now correctly handle singleton lookups instead of failing with "not found"
- Bump idfkit to 0.6.2 for the underlying `IDFCollection.get("")` fix

## Test plan
- [x] New `TestGetObjectSingleton` tests (empty name, type-as-name, multiple singleton types)
- [x] New `TestUpdateObjectSingleton` and `TestRemoveObjectSingleton` tests
- [x] All 135 existing tests pass
- [x] `make check` passes (lint, format, typecheck, deptry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)