### PR TITLE
Add per-session state isolation and tool call logging

### DIFF
--- a/src/idfkit_mcp/errors.py
+++ b/src/idfkit_mcp/errors.py
@@ -1,35 +1,151 @@
-"""Unified error formatting for MCP tool responses."""
+"""Unified error formatting, logging, and session management for MCP tools."""
 
 from __future__ import annotations
 
+import inspect
 import json
+import logging
+import time
+import typing
 from collections.abc import Callable
 from functools import wraps
-from typing import TypeVar
+from typing import Any, TypeVar
 
+from mcp.server.fastmcp import Context
 from mcp.server.fastmcp.exceptions import ToolError
 
 _T = TypeVar("_T")
 
+logger = logging.getLogger("idfkit_mcp")
+
+_PAYLOAD_MAX_LEN = 500
+"""Maximum characters for truncated payload logging."""
+
+
+# ---------------------------------------------------------------------------
+# Logging helpers
+# ---------------------------------------------------------------------------
+
+
+def _summarize_kwargs(kwargs: dict[str, Any]) -> str:
+    """Summarize tool input kwargs for log output, truncated."""
+    try:
+        s = json.dumps(kwargs, default=str)
+    except Exception:
+        s = str(kwargs)
+    return s if len(s) <= _PAYLOAD_MAX_LEN else s[:_PAYLOAD_MAX_LEN] + "…"
+
+
+def _summarize_result(result: object) -> str:
+    """Summarize tool result for log output, truncated."""
+    try:
+        s = json.dumps(result, default=str)  # type: ignore[reportArgumentType]
+    except Exception:
+        s = str(result)
+    return s if len(s) <= _PAYLOAD_MAX_LEN else s[:_PAYLOAD_MAX_LEN] + "…"
+
+
+# ---------------------------------------------------------------------------
+# Tool decorator
+# ---------------------------------------------------------------------------
+
 
 def safe_tool(func: Callable[..., _T]) -> Callable[..., _T]:
-    """Convert exceptions into MCP ``ToolError`` instances.
+    """Decorator for MCP tool functions.
 
-    Decorator for MCP tool functions that catches all exceptions and
-    re-raises them as ``ToolError`` with a human-readable message.
-    The MCP SDK surfaces these to clients via ``isError=True`` responses.
+    Wraps each tool invocation with:
+
+    1. **Per-session state** — extracts the MCP session ID from an
+       auto-injected ``Context`` and sets the ``contextvars`` token so
+       that :func:`~idfkit_mcp.state.get_state` returns the correct
+       per-session :class:`~idfkit_mcp.state.ServerState`.
+    2. **Error handling** — catches all exceptions and re-raises them as
+       ``ToolError`` with a human-readable message.
+    3. **Logging** — emits structured log lines for every call with tool
+       name, session ID, wall-clock timing (ms), and truncated payloads.
     """
 
     @wraps(func)
     def wrapper(*args: object, **kwargs: object) -> _T:
+        # Pop the Context injected by FastMCP (not visible to clients).
+        ctx = kwargs.pop("ctx", None)
+        if ctx is not None:
+            from idfkit_mcp.state import set_session_from_context
+
+            session_id = set_session_from_context(ctx)
+        else:
+            session_id = "local"
+
+        tool_name = func.__name__
+        logger.info(
+            "CALL %s | session=%s | %s",
+            tool_name,
+            session_id,
+            _summarize_kwargs(dict(kwargs)),  # type: ignore[arg-type]
+        )
+
+        start = time.monotonic()
         try:
-            return func(*args, **kwargs)
+            result = func(*args, **kwargs)
         except ToolError:
+            elapsed_ms = (time.monotonic() - start) * 1000
+            logger.warning(
+                "FAIL %s | session=%s | %.1fms",
+                tool_name,
+                session_id,
+                elapsed_ms,
+                exc_info=True,
+            )
             raise
         except Exception as e:
-            raise ToolError(format_error(e)) from e
+            elapsed_ms = (time.monotonic() - start) * 1000
+            error_msg = format_error(e)
+            logger.exception(
+                "ERR  %s | session=%s | %.1fms | %s",
+                tool_name,
+                session_id,
+                elapsed_ms,
+                error_msg,
+            )
+            raise ToolError(error_msg) from e
+        else:
+            elapsed_ms = (time.monotonic() - start) * 1000
+            logger.info(
+                "OK   %s | session=%s | %.1fms | %s",
+                tool_name,
+                session_id,
+                elapsed_ms,
+                _summarize_result(result),
+            )
+            return result
 
-    return wrapper
+    # Build a fully-resolved signature for the wrapper that includes a
+    # ``ctx: Context`` parameter.  We must resolve string annotations
+    # (from ``from __future__ import annotations``) using the ORIGINAL
+    # function's module globals — the wrapper lives in errors.py which
+    # does not have the tool-specific return types in scope.
+    try:
+        hints = typing.get_type_hints(func)
+    except Exception:
+        hints = {}
+
+    sig = inspect.signature(func)
+    resolved_params = [
+        param.replace(annotation=hints.get(name, param.annotation)) for name, param in sig.parameters.items()
+    ]
+    resolved_params.append(inspect.Parameter("ctx", inspect.Parameter.KEYWORD_ONLY, annotation=Context))
+
+    wrapper.__signature__ = inspect.Signature(  # type: ignore[attr-defined]
+        parameters=resolved_params,
+        return_annotation=hints.get("return", sig.return_annotation),
+    )
+
+    return wrapper  # type: ignore[return-value]
+
+
+# ---------------------------------------------------------------------------
+# Error formatting
+# ---------------------------------------------------------------------------
 
 
 def format_error(error: Exception) -> str:

--- a/src/idfkit_mcp/server.py
+++ b/src/idfkit_mcp/server.py
@@ -76,6 +76,14 @@ def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
 
 def main() -> None:
     """Run the MCP server with configurable transport."""
+    import logging
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)-5s [%(name)s] %(message)s",
+        datefmt="%H:%M:%S",
+    )
+
     args = _parse_args()
     server = create_server(host=args.host, port=args.port)
 

--- a/src/idfkit_mcp/state.py
+++ b/src/idfkit_mcp/state.py
@@ -1,8 +1,17 @@
-"""Server state management for the idfkit MCP server."""
+"""Server state management for the idfkit MCP server.
+
+State is keyed per MCP session so that concurrent ``streamable-http``
+connections each get their own model, simulation result, etc.  For
+``stdio`` transport (single client) a fixed ``"stdio"`` session ID is
+used, behaving identically to the previous singleton approach.
+"""
 
 from __future__ import annotations
 
+import contextvars
 import dataclasses
+import logging
+from collections import OrderedDict
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 from urllib.request import urlopen
@@ -15,8 +24,20 @@ if TYPE_CHECKING:
     from idfkit.simulation.result import SimulationResult
     from idfkit.weather.index import StationIndex
 
+logger = logging.getLogger("idfkit_mcp")
 
 DOCS_BASE_URL = "https://docs.idfkit.com"
+
+# ---------------------------------------------------------------------------
+# Per-session state registry
+# ---------------------------------------------------------------------------
+
+_current_session_id: contextvars.ContextVar[str] = contextvars.ContextVar("current_session_id", default="stdio")
+
+_sessions: OrderedDict[str, ServerState] = OrderedDict()
+
+_MAX_SESSIONS = 20
+"""Maximum number of concurrent sessions before LRU eviction."""
 
 
 def _cache_base_dir() -> Path:
@@ -106,18 +127,19 @@ def _read_session_file() -> dict[str, Any] | None:
 
 @dataclasses.dataclass
 class ServerState:
-    """Holds the active document, schema, and simulation result.
+    """Holds the active document, schema, and simulation result for one session.
 
-    MCP stdio transport is single-threaded, so a module-level instance is safe.
+    Instances are created and managed by :func:`get_state`, which keys them
+    by MCP session ID.  For ``stdio`` transport a fixed ``"stdio"`` key is
+    used (single-client, equivalent to the old singleton).  For
+    ``streamable-http`` each connection gets an isolated instance keyed by
+    the ``Mcp-Session-Id`` header.
 
     Session state (file_path, simulation run dir, weather file) is persisted
     to a JSON file on disk so that clients that restart the server between
     turns (e.g. Codex) can transparently resume where they left off.
-
-    WARNING: For streamable-http or SSE transports with multiple concurrent
-    clients, this singleton will cause cross-session state contamination.
-    A future improvement should key state by session/connection ID using
-    FastMCP's ``context.session`` or a similar mechanism.
+    Persistence is disabled for HTTP sessions since they receive a new
+    session ID on every connection.
     """
 
     document: IDFDocument | None = None
@@ -130,9 +152,12 @@ class ServerState:
     docs_version: str | None = None
     docs_separator: str | None = None
 
-    # Session persistence control
+    # Session persistence control (disabled for HTTP sessions)
     persistence_enabled: bool = True
     _session_restored: bool = dataclasses.field(default=False, repr=False)
+
+    # Informational — set when the session is created via get_state()
+    session_id: str = dataclasses.field(default="stdio", repr=False)
 
     def require_model(self) -> IDFDocument:
         """Return the active document, auto-restoring from session if needed."""
@@ -358,10 +383,64 @@ class ServerState:
         self._session_restored = False
 
 
-# Module-level singleton
-_state = ServerState()
+def _extract_session_id(ctx: Any) -> str:
+    """Extract the MCP session ID from a FastMCP ``Context``.
+
+    Falls back to ``"stdio"`` when no session header is present (e.g. stdio
+    transport or direct function calls in tests).
+    """
+    try:
+        request = ctx.request_context.request
+        if request is not None and hasattr(request, "headers"):
+            sid = request.headers.get("mcp-session-id")
+            if sid:
+                return sid
+    except Exception:
+        logger.debug("Could not extract session ID from context", exc_info=True)
+    return "stdio"
+
+
+def set_session_from_context(ctx: Any) -> str:
+    """Set the current session from a FastMCP ``Context``.
+
+    Called by the ``safe_tool`` decorator before each tool invocation.
+    Returns the resolved session ID.
+    """
+    session_id = _extract_session_id(ctx)
+    _current_session_id.set(session_id)
+    return session_id
 
 
 def get_state() -> ServerState:
-    """Return the module-level server state."""
-    return _state
+    """Return the ``ServerState`` for the current MCP session.
+
+    Creates a new state on first access for a given session ID and evicts
+    the least-recently-used session when the registry is full.
+    """
+    session_id = _current_session_id.get()
+
+    if session_id in _sessions:
+        _sessions.move_to_end(session_id)
+        return _sessions[session_id]
+
+    # Evict oldest sessions when at capacity
+    while len(_sessions) >= _MAX_SESSIONS:
+        evicted_id, _ = _sessions.popitem(last=False)
+        logger.info("Evicted session %s (capacity %d)", evicted_id, _MAX_SESSIONS)
+
+    state = ServerState(session_id=session_id)
+    # HTTP sessions are ephemeral — no point persisting to disk
+    if session_id != "stdio":
+        state.persistence_enabled = False
+    _sessions[session_id] = state
+    logger.debug("Created session %s", session_id)
+    return state
+
+
+def reset_sessions() -> None:
+    """Clear all sessions and reset to the default ``"stdio"`` session.
+
+    Intended for test fixtures only.
+    """
+    _sessions.clear()
+    _current_session_id.set("stdio")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,24 +5,15 @@ from __future__ import annotations
 import pytest
 from idfkit import new_document
 
-from idfkit_mcp.state import ServerState, get_state
+from idfkit_mcp.state import ServerState, get_state, reset_sessions
 
 
 @pytest.fixture(autouse=True)
 def _reset_state() -> None:
-    """Reset the module-level server state before each test."""
+    """Reset the session registry before each test."""
+    reset_sessions()
     state = get_state()
-    state.document = None
-    state.schema = None
-    state.file_path = None
-    state.simulation_result = None
-    state.weather_file = None
-    state.station_index = None
-    state.docs_index = None
-    state.docs_version = None
-    state.docs_separator = None
     state.persistence_enabled = False
-    state._session_restored = False
 
 
 @pytest.fixture()


### PR DESCRIPTION
## Summary
- Replace singleton `ServerState` with a per-session registry keyed by `Mcp-Session-Id` header, preventing cross-session state contamination on `streamable-http` deployments
- LRU eviction at 20 sessions; HTTP sessions are ephemeral (no disk persistence)
- Enhance `safe_tool` decorator with structured logging: tool name, session ID, timing (ms), and truncated I/O payloads
- Add `logging.basicConfig()` to server startup for consistent log formatting

## Test plan
- [x] All 135 tests pass (session registry reset between tests via `reset_sessions()`)
- [x] `make check` passes (lint, format, typecheck, deptry)
- [x] Session persistence tests still pass (keyed to "stdio" for stdio transport)
- [ ] Manual verification with streamable-http transport (multiple concurrent clients)

🤖 Generated with [Claude Code](https://claude.com/claude-code)