### PR TITLE
Add comprehensive per-tool logging with configurable log levels

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -109,6 +109,25 @@ idfkit-mcp --transport streamable-http --host 127.0.0.1 --port 8000
 IDFKIT_MCP_TRANSPORT=streamable-http IDFKIT_MCP_HOST=0.0.0.0 IDFKIT_MCP_PORT=8000 idfkit-mcp
 ```
 
+## Log Verbosity
+
+Control log output with `--log-level` (or the `IDFKIT_MCP_LOG_LEVEL` environment variable).
+The default level is `INFO`.
+
+```bash
+idfkit-mcp --log-level DEBUG
+```
+
+Available levels: `DEBUG`, `INFO`, `WARNING`, `ERROR`.
+
+At `DEBUG` level the server emits per-tool CALL/OK traces, idfkit core parsing
+details (schema loading, IDF/epJSON parsing, validation internals), and
+query/search parameters for every tool invocation.
+
+At `INFO` (default) the server logs significant operations — model loads, saves,
+simulation start/completion, object mutations, and weather downloads — without
+the high-frequency per-call noise.
+
 ## EnergyPlus Discovery
 
 Simulation tools rely on `idfkit`'s EnergyPlus discovery chain:

--- a/docs/troubleshooting/setup.md
+++ b/docs/troubleshooting/setup.md
@@ -1,5 +1,23 @@
 # Setup & Configuration
 
+## Enable Debug Logging
+
+When troubleshooting any issue, start by enabling debug output:
+
+```bash
+idfkit-mcp --log-level DEBUG
+```
+
+Or via environment variable:
+
+```bash
+IDFKIT_MCP_LOG_LEVEL=DEBUG idfkit-mcp
+```
+
+This reveals per-tool CALL/OK traces with timing, idfkit core library details
+(parsing, schema loading, validation), and query parameters — making it much
+easier to pinpoint failures.
+
 ## Server Does Not Start
 
 ### Symptom

--- a/src/idfkit_mcp/errors.py
+++ b/src/idfkit_mcp/errors.py
@@ -77,7 +77,7 @@ def safe_tool(func: Callable[..., _T]) -> Callable[..., _T]:
             session_id = "local"
 
         tool_name = func.__name__
-        logger.info(
+        logger.debug(
             "CALL %s | session=%s | %s",
             tool_name,
             session_id,
@@ -110,7 +110,7 @@ def safe_tool(func: Callable[..., _T]) -> Callable[..., _T]:
             raise ToolError(error_msg) from e
         else:
             elapsed_ms = (time.monotonic() - start) * 1000
-            logger.info(
+            logger.debug(
                 "OK   %s | session=%s | %.1fms | %s",
                 tool_name,
                 session_id,

--- a/src/idfkit_mcp/server.py
+++ b/src/idfkit_mcp/server.py
@@ -47,6 +47,9 @@ def create_server(host: str = "127.0.0.1", port: int = 8000) -> FastMCP:
 mcp = create_server()
 
 
+_LOG_LEVELS = ("DEBUG", "INFO", "WARNING", "ERROR")
+
+
 def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description="Run the idfkit MCP server.")
     parser.add_argument(
@@ -54,6 +57,12 @@ def _parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         choices=get_args(Transport),
         default=os.getenv("IDFKIT_MCP_TRANSPORT", "stdio"),
         help="MCP transport to run.",
+    )
+    parser.add_argument(
+        "--log-level",
+        choices=_LOG_LEVELS,
+        default=os.getenv("IDFKIT_MCP_LOG_LEVEL", "INFO"),
+        help="Log verbosity (default: INFO, env: IDFKIT_MCP_LOG_LEVEL).",
     )
     parser.add_argument(
         "--host",
@@ -78,13 +87,19 @@ def main() -> None:
     """Run the MCP server with configurable transport."""
     import logging
 
+    args = _parse_args()
+    level = getattr(logging, args.log_level)
+
     logging.basicConfig(
-        level=logging.INFO,
+        level=level,
         format="%(asctime)s %(levelname)-5s [%(name)s] %(message)s",
         datefmt="%H:%M:%S",
     )
 
-    args = _parse_args()
+    # Capture idfkit core library logs (parser, schema, validation, geometry).
+    # The library installs a NullHandler by default; setting a level here lets
+    # its messages propagate through to the root handler configured above.
+    logging.getLogger("idfkit").setLevel(level)
     server = create_server(host=args.host, port=args.port)
 
     run_kwargs: dict[str, str | None] = {"transport": args.transport}

--- a/src/idfkit_mcp/tools/docs.py
+++ b/src/idfkit_mcp/tools/docs.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import re
 from html.parser import HTMLParser
 
@@ -17,6 +18,8 @@ from idfkit_mcp.models import (
     SearchDocsResult,
 )
 from idfkit_mcp.state import DOCS_BASE_URL, get_state
+
+logger = logging.getLogger(__name__)
 
 _READ_ONLY = ToolAnnotations(readOnlyHint=True, destructiveHint=False, idempotentHint=True, openWorldHint=False)
 
@@ -196,6 +199,7 @@ def search_docs(
             )
         )
 
+    logger.debug("search_docs: query=%r version=%s matched=%d", query, docs_version, len(results))
     return SearchDocsResult(
         query=query,
         version=docs_version,
@@ -219,6 +223,7 @@ def get_doc_section(location: str, version: str | None = None) -> GetDocSectionR
     state = get_state()
     items, _separator, docs_version = state.get_or_load_docs_index(version)
 
+    logger.debug("get_doc_section: location=%r version=%s", location, version)
     for item in items:
         if item.get("location") == location:
             return GetDocSectionResult(

--- a/src/idfkit_mcp/tools/read.py
+++ b/src/idfkit_mcp/tools/read.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Any, cast
 
 from mcp.server.fastmcp import FastMCP
@@ -20,6 +21,8 @@ from idfkit_mcp.models import (
 from idfkit_mcp.serializers import serialize_object
 from idfkit_mcp.state import get_state
 from idfkit_mcp.tools import resolve_object
+
+logger = logging.getLogger(__name__)
 
 _READ_ONLY = ToolAnnotations(readOnlyHint=True, destructiveHint=False, idempotentHint=True, openWorldHint=False)
 _LOAD = ToolAnnotations(readOnlyHint=False, destructiveHint=False, idempotentHint=True, openWorldHint=False)
@@ -58,6 +61,7 @@ def load_model(file_path: str, version: str | None = None) -> ModelSummary:
     state.simulation_result = None
     state.save_session()
 
+    logger.info("Loaded model %s (version=%s, objects=%d)", path, doc.version, len(list(doc.all_objects)))
     return _build_summary(doc, state)
 
 
@@ -140,6 +144,7 @@ def convert_osm_to_idf(
     state.file_path = out_path
     state.simulation_result = None
     state.save_session()
+    logger.info("Converted OSM %s -> %s", input_path, out_path)
 
     version_getter = getattr(openstudio, "openStudioVersion", None)
     openstudio_version = str(version_getter()) if callable(version_getter) else "unknown"
@@ -190,6 +195,7 @@ def list_objects(object_type: str, limit: int = 50) -> ListObjectsResult:
     total = len(collection)
     objects = [serialize_object(obj, schema=state.schema, brief=True) for obj in list(collection)[:limit]]
 
+    logger.debug("list_objects: type=%s total=%d returned=%d", object_type, total, len(objects))
     return ListObjectsResult(object_type=object_type, total=total, returned=len(objects), objects=objects)
 
 
@@ -233,6 +239,7 @@ def search_objects(query: str, object_type: str | None = None, limit: int = 20) 
             if len(matches) >= limit:
                 break
 
+    logger.debug("search_objects: query=%r type=%s matched=%d", query, object_type, len(matches))
     return SearchObjectsResult.model_validate({"query": query, "count": len(matches), "matches": matches})
 
 

--- a/src/idfkit_mcp/tools/schema.py
+++ b/src/idfkit_mcp/tools/schema.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+
 from mcp.server.fastmcp import FastMCP
 from mcp.types import ToolAnnotations
 
@@ -15,6 +17,8 @@ from idfkit_mcp.models import (
 )
 from idfkit_mcp.serializers import serialize_object_description
 from idfkit_mcp.state import get_state
+
+logger = logging.getLogger(__name__)
 
 _READ_ONLY = ToolAnnotations(readOnlyHint=True, destructiveHint=False, idempotentHint=True, openWorldHint=False)
 
@@ -59,6 +63,7 @@ def list_object_types(group: str | None = None, version: str | None = None, limi
 
     total_types = sum(len(v) for v in groups.values())
     truncated = total_types > limit
+    logger.debug("list_object_types: group=%s total=%d truncated=%s", group, total_types, truncated)
 
     if truncated:
         groups_result = {g: GroupInfo(count=len(types)) for g, types in sorted(groups.items())}
@@ -87,6 +92,7 @@ def describe_object_type(object_type: str, version: str | None = None) -> Descri
     ver_tuple = _parse_version(version)
     schema = state.get_or_load_schema(ver_tuple)
     desc = _describe(schema, object_type)
+    logger.debug("describe_object_type: %s version=%s", object_type, version)
     data = serialize_object_description(desc)
 
     doc_url = _get_doc_url(object_type, ver_tuple, schema, docs_url_for_object)
@@ -128,6 +134,7 @@ def search_schema(query: str, version: str | None = None, limit: int = 50) -> Se
             if len(matches) >= limit:
                 break
 
+    logger.debug("search_schema: query=%r matched=%d/%d", query, len(matches), limit)
     return SearchSchemaResult.model_validate({
         "query": query,
         "count": len(matches),
@@ -168,6 +175,7 @@ def get_available_references(object_type: str, field_name: str) -> AvailableRefe
             available[list_name] = sorted(names)
 
     all_names = sorted({n for names in available.values() for n in names})
+    logger.debug("get_available_references: %s.%s found %d names", object_type, field_name, len(all_names))
     return AvailableReferencesResult(
         object_type=object_type,
         field_name=field_name,

--- a/src/idfkit_mcp/tools/simulation.py
+++ b/src/idfkit_mcp/tools/simulation.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from sqlite3 import OperationalError
 from typing import Any, Literal
 
@@ -18,6 +19,8 @@ from idfkit_mcp.models import (
     RunSimulationResult,
 )
 from idfkit_mcp.state import get_state
+
+logger = logging.getLogger(__name__)
 
 _READ_ONLY = ToolAnnotations(readOnlyHint=True, destructiveHint=False, idempotentHint=True, openWorldHint=False)
 _RUN = ToolAnnotations(readOnlyHint=False, destructiveHint=False, idempotentHint=False, openWorldHint=True)
@@ -69,6 +72,13 @@ def run_simulation(
         )
 
     config = find_energyplus(path=energyplus_dir, version=energyplus_version)
+    logger.info(
+        "Starting simulation (EnergyPlus %s, weather=%s, design_day=%s, annual=%s)",
+        ".".join(str(p) for p in config.version),
+        epw_path,
+        design_day,
+        annual,
+    )
 
     output_dir = Path(output_directory) if output_directory is not None else None
     weather = epw_path if epw_path is not None else ""
@@ -78,6 +88,11 @@ def run_simulation(
 
     state.simulation_result = result
     state.save_session()
+
+    if result.success:
+        logger.info("Simulation completed in %.1fs", result.runtime_seconds)
+    else:
+        logger.warning("Simulation failed after %.1fs", result.runtime_seconds)
 
     errors = result.errors
 
@@ -243,6 +258,14 @@ def query_timeseries(
         {"timestamp": ts.timestamps[i].isoformat(), "value": ts.values[i]} for i in range(min(limit, len(ts.values)))
     ]
 
+    logger.debug(
+        "query_timeseries: %s key=%s freq=%s total=%d returned=%d",
+        variable_name,
+        key_value,
+        frequency,
+        len(ts.values),
+        len(rows),
+    )
     return QueryTimeseriesResult.model_validate({
         "variable_name": ts.variable_name,
         "key_value": ts.key_value,
@@ -310,6 +333,7 @@ def export_timeseries(
         for i in range(len(ts.values)):
             writer.writerow([ts.timestamps[i].isoformat(), ts.values[i]])
 
+    logger.info("Exported timeseries %r to %s (%d rows)", variable_name, csv_path, len(ts.values))
     return ExportTimeseriesResult(
         path=str(csv_path),
         variable_name=ts.variable_name,

--- a/src/idfkit_mcp/tools/validation.py
+++ b/src/idfkit_mcp/tools/validation.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+
 from mcp.server.fastmcp import FastMCP
 from mcp.types import ToolAnnotations
 
@@ -9,6 +11,8 @@ from idfkit_mcp.errors import safe_tool
 from idfkit_mcp.models import CheckReferencesResult, ValidationResult
 from idfkit_mcp.serializers import serialize_validation_result
 from idfkit_mcp.state import get_state
+
+logger = logging.getLogger(__name__)
 
 _READ_ONLY = ToolAnnotations(readOnlyHint=True, destructiveHint=False, idempotentHint=True, openWorldHint=False)
 
@@ -27,8 +31,15 @@ def validate_model(object_types: list[str] | None = None, check_references: bool
 
     state = get_state()
     doc = state.require_model()
+    if not list(doc.all_objects):
+        logger.warning("validate_model: model has no objects")
     result = validate_document(doc, check_references=check_references, object_types=object_types)
     data = serialize_validation_result(result, version=doc.version)  # type: ignore[arg-type]
+    logger.info(
+        "Validation complete: %d errors, %d warnings",
+        data.get("error_count", 0),
+        data.get("warning_count", 0),
+    )
     return ValidationResult.model_validate(data)
 
 
@@ -56,6 +67,10 @@ def check_references() -> CheckReferencesResult:
             "missing_target": target,
         })
 
+    if dangling:
+        logger.warning("Found %d dangling reference(s)", len(dangling))
+    else:
+        logger.info("No dangling references found")
     return CheckReferencesResult.model_validate({"dangling_count": len(dangling), "dangling_references": dangling})
 
 

--- a/src/idfkit_mcp/tools/weather.py
+++ b/src/idfkit_mcp/tools/weather.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 
 from mcp.server.fastmcp import FastMCP
@@ -12,6 +13,8 @@ from idfkit_mcp.errors import safe_tool
 from idfkit_mcp.models import DownloadWeatherFileResult, SearchWeatherStationsResult
 from idfkit_mcp.serializers import serialize_station
 from idfkit_mcp.state import get_state
+
+logger = logging.getLogger(__name__)
 
 _READ_ONLY_OPEN = ToolAnnotations(readOnlyHint=True, destructiveHint=False, idempotentHint=True, openWorldHint=True)
 _DOWNLOAD = ToolAnnotations(readOnlyHint=False, destructiveHint=False, idempotentHint=True, openWorldHint=True)
@@ -55,6 +58,9 @@ def search_weather_stations(
                 **serialize_station(r.station),
                 "distance_km": round(r.distance_km, 1),
             })
+        logger.debug(
+            "search_weather_stations: spatial lat=%s lon=%s found=%d", latitude, longitude, len(spatial_stations)
+        )
         return SearchWeatherStationsResult(
             search_type="spatial",
             count=len(spatial_stations),
@@ -74,6 +80,7 @@ def search_weather_stations(
             })
             if len(text_stations) >= limit:
                 break
+        logger.debug("search_weather_stations: query=%r found=%d", query, len(text_stations))
         return SearchWeatherStationsResult(
             search_type="text",
             query=query,
@@ -139,12 +146,14 @@ def download_weather_file(
     else:
         raise ToolError("Provide either 'wmo' or 'query' to identify the weather station.")
 
+    logger.info("Downloading weather file for station %s (%s)", station.wmo, station.city)
     downloader = WeatherDownloader()
     files = downloader.download(station)
 
     server_state = get_state()
     server_state.weather_file = files.epw
     server_state.save_session()
+    logger.info("Downloaded weather file to %s", files.epw)
 
     return DownloadWeatherFileResult.model_validate({
         "status": "downloaded",

--- a/src/idfkit_mcp/tools/write.py
+++ b/src/idfkit_mcp/tools/write.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from typing import Any, Literal
 
 from mcp.server.fastmcp import FastMCP
@@ -21,6 +22,8 @@ from idfkit_mcp.models import (
 from idfkit_mcp.serializers import serialize_object
 from idfkit_mcp.state import get_state
 from idfkit_mcp.tools import resolve_object
+
+logger = logging.getLogger(__name__)
 
 _MUTATE = ToolAnnotations(readOnlyHint=False, destructiveHint=False, idempotentHint=False, openWorldHint=False)
 _DESTRUCTIVE = ToolAnnotations(readOnlyHint=False, destructiveHint=True, idempotentHint=False, openWorldHint=False)
@@ -50,6 +53,7 @@ def new_model(version: str | None = None) -> NewModelResult:
     state.file_path = None
     state.simulation_result = None
 
+    logger.info("Created new model (version=%s)", version_string(ver))
     return NewModelResult(status="created", version=version_string(ver))
 
 
@@ -69,6 +73,8 @@ def add_object(object_type: str, name: str = "", fields: dict[str, Any] | None =
     doc = state.require_model()
     kwargs = fields or {}
     obj = doc.add(object_type, name, **kwargs)
+    logger.info("Added %s %r", object_type, name)
+    logger.debug("add_object fields: %s", kwargs)
     return serialize_object(obj)
 
 
@@ -108,6 +114,9 @@ def batch_add_objects(objects: list[dict[str, Any]]) -> BatchAddResult:
             results.append({"index": i, "error": str(e)})
             error_count += 1
 
+    logger.info("Batch add: %d total, %d success, %d errors", len(objects), success_count, error_count)
+    if error_count:
+        logger.warning("batch_add_objects: %d/%d objects failed", error_count, len(objects))
     return BatchAddResult(total=len(objects), success=success_count, errors=error_count, results=results)
 
 
@@ -129,6 +138,8 @@ def update_object(object_type: str, name: str, fields: dict[str, Any]) -> dict[s
     for field_name, value in fields.items():
         setattr(obj, field_name, value)
 
+    logger.info("Updated %s %r (%d fields)", object_type, name, len(fields))
+    logger.debug("update_object fields: %s", fields)
     return serialize_object(obj)
 
 
@@ -158,6 +169,7 @@ def remove_object(object_type: str, name: str, force: bool = False) -> RemoveObj
             )
 
     doc.removeidfobject(obj)
+    logger.info("Removed %s %r", object_type, obj.name)
     return RemoveObjectResult(status="removed", object_type=object_type, name=obj.name)
 
 
@@ -179,6 +191,7 @@ def rename_object(object_type: str, old_name: str, new_name: str) -> RenameObjec
     ref_count = len(referencing_before)
 
     doc.rename(object_type, old_name, new_name)
+    logger.info("Renamed %s %r -> %r (%d references updated)", object_type, old_name, new_name, ref_count)
 
     return RenameObjectResult(
         status="renamed",
@@ -205,6 +218,7 @@ def duplicate_object(object_type: str, name: str, new_name: str) -> dict[str, An
     source = resolve_object(doc, object_type, name)
 
     obj = doc.copyidfobject(source, new_name=new_name)
+    logger.info("Duplicated %s %r as %r", object_type, name, new_name)
     return serialize_object(obj)
 
 
@@ -232,6 +246,9 @@ def save_model(file_path: str | None = None, output_format: Literal["idf", "epjs
     else:
         raise ToolError("No file path specified and no original path available.")
 
+    if path.exists():
+        logger.warning("Overwriting existing file: %s", path)
+
     if output_format == "epjson":
         write_epjson(doc, path)
     else:
@@ -239,6 +256,7 @@ def save_model(file_path: str | None = None, output_format: Literal["idf", "epjs
 
     state.file_path = path
     state.save_session()
+    logger.info("Saved model to %s (format=%s)", path, output_format)
     return SaveModelResult(status="saved", file_path=str(path), format=output_format)
 
 


### PR DESCRIPTION
## Summary
- Add `--log-level` CLI arg and `IDFKIT_MCP_LOG_LEVEL` env var to control verbosity (DEBUG/INFO/WARNING/ERROR)
- Capture idfkit core library logs (parser, schema, validation, geometry) in the server
- Add per-module loggers to all 7 tool modules with contextual DEBUG/INFO/WARNING messages
- Demote CALL/OK decorator traces from INFO to DEBUG for cleaner default output
- Document the new logging options in installation and troubleshooting docs

## Test plan
- [x] `make check` passes (ruff, pyright, deptry)
- [x] `make test` passes (135 tests)
- [ ] Manual: `idfkit-mcp --log-level DEBUG` shows idfkit core + per-tool traces
- [ ] Manual: default INFO level shows significant operations only

🤖 Generated with [Claude Code](https://claude.com/claude-code)