### PR TITLE
Fix ctx: Context leaking into MCP tool schemas

### DIFF
--- a/src/idfkit_mcp/errors.py
+++ b/src/idfkit_mcp/errors.py
@@ -135,6 +135,12 @@ def safe_tool(func: Callable[..., _T]) -> Callable[..., _T]:
     ]
     resolved_params.append(inspect.Parameter("ctx", inspect.Parameter.KEYWORD_ONLY, annotation=Context))
 
+    # Expose ctx in __annotations__ so typing.get_type_hints(wrapper) includes
+    # it.  FastMCP's find_context_parameter() uses get_type_hints — without this
+    # it resolves through __wrapped__ to the original (which lacks ctx), causing
+    # ctx to appear as a required client-visible parameter in the tool schema.
+    wrapper.__annotations__ = {**hints, "ctx": Context}
+
     wrapper.__signature__ = inspect.Signature(  # type: ignore[attr-defined]
         parameters=resolved_params,
         return_annotation=hints.get("return", sig.return_annotation),


### PR DESCRIPTION
## Summary

- The `safe_tool` decorator added `ctx: Context` to the wrapper's `__signature__` (used by Pydantic for schema generation) but not to `__annotations__` (used by `typing.get_type_hints`, which FastMCP's `find_context_parameter` reads)
- This caused `ctx` to appear as a **required client-visible parameter** in every tool's JSON schema, breaking all MCP clients (e.g., Claude Code fails with Pydantic validation error)
- Fix: set `wrapper.__annotations__` to include `ctx: Context` so `get_type_hints` returns it, allowing FastMCP to correctly set `context_kwarg='ctx'` and exclude it from the schema

## Test plan

- [x] `make check` passes (lint, format, pyright, deptry)
- [x] `make test` passes (135 tests)
- [x] Verified with isolated test: `context_kwarg='ctx'` is set, `ctx` absent from tool schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)