### PR TITLE
Register MCP tools with decorators

### DIFF
--- a/src/idfkit_mcp/app.py
+++ b/src/idfkit_mcp/app.py
@@ -1,0 +1,25 @@
+"""Shared FastMCP application instance."""
+
+from __future__ import annotations
+
+from fastmcp import FastMCP
+
+from idfkit_mcp.errors import ToolExecutionMiddleware
+
+_INSTRUCTIONS = (
+    "EnergyPlus model editor powered by idfkit. "
+    "Create, edit, validate, and simulate building energy models.\n\n"
+    "Guidelines:\n"
+    "- Use get_model_summary first to understand any loaded model\n"
+    "- Call describe_object_type before creating/editing objects to know valid fields\n"
+    "- Use batch_add_objects when creating multiple objects (minimizes round-trips)\n"
+    "- Validate after modifications with validate_model\n"
+    "- For reference fields, use get_available_references to see valid values\n"
+    "- Check references before removing objects (remove_object warns by default)\n"
+    "- Use lookup_documentation to get docs.idfkit.com URLs for any object type\n"
+    "- Use search_docs to find relevant EnergyPlus documentation sections\n"
+    "- Use get_doc_section to read the full content of a documentation section"
+)
+
+mcp = FastMCP("idfkit", instructions=_INSTRUCTIONS)
+mcp.add_middleware(ToolExecutionMiddleware())

--- a/src/idfkit_mcp/server.py
+++ b/src/idfkit_mcp/server.py
@@ -9,11 +9,18 @@ from typing import Literal
 
 from fastmcp import FastMCP
 
-from idfkit_mcp.errors import ToolExecutionMiddleware
-from idfkit_mcp.tools import docs, read, schema, simulation, validation, weather, write
+from idfkit_mcp.app import mcp
+from idfkit_mcp.tools import docs as _docs
+from idfkit_mcp.tools import read as _read
+from idfkit_mcp.tools import schema as _schema
+from idfkit_mcp.tools import simulation as _simulation
+from idfkit_mcp.tools import validation as _validation
+from idfkit_mcp.tools import weather as _weather
+from idfkit_mcp.tools import write as _write
 
 Transport = Literal["stdio", "sse", "http"]
 _TRANSPORT_CHOICES = ("stdio", "sse", "http", "streamable-http")
+_REGISTERED_MODULES = (_docs, _read, _schema, _simulation, _validation, _weather, _write)
 
 _INSTRUCTIONS = (
     "EnergyPlus model editor powered by idfkit. "
@@ -32,22 +39,8 @@ _INSTRUCTIONS = (
 
 
 def create_server() -> FastMCP:
-    """Create a configured FastMCP instance and register all tools."""
-    server = FastMCP("idfkit", instructions=_INSTRUCTIONS)
-    server.add_middleware(ToolExecutionMiddleware())
-
-    schema.register(server)
-    read.register(server)
-    write.register(server)
-    validation.register(server)
-    simulation.register(server)
-    weather.register(server)
-    docs.register(server)
-    return server
-
-
-# Module-level instance used by tests to introspect registered tools.
-mcp = create_server()
+    """Return the configured FastMCP instance."""
+    return mcp
 
 
 _LOG_LEVELS = ("DEBUG", "INFO", "WARNING", "ERROR")

--- a/src/idfkit_mcp/tools/docs.py
+++ b/src/idfkit_mcp/tools/docs.py
@@ -6,10 +6,10 @@ import logging
 import re
 from html.parser import HTMLParser
 
-from fastmcp import FastMCP
 from fastmcp.exceptions import ToolError
 from mcp.types import ToolAnnotations
 
+from idfkit_mcp.app import mcp
 from idfkit_mcp.models import (
     DocSearchHit,
     GetDocSectionResult,
@@ -104,6 +104,7 @@ def _score_item(item: dict[str, object], query_tokens: list[str], separator: str
 # ---------------------------------------------------------------------------
 
 
+@mcp.tool(annotations=_READ_ONLY)
 def lookup_documentation(object_type: str, version: str | None = None) -> LookupDocumentationResult:
     """Get documentation URLs for an EnergyPlus object type on docs.idfkit.com.
 
@@ -136,6 +137,7 @@ def lookup_documentation(object_type: str, version: str | None = None) -> Lookup
     )
 
 
+@mcp.tool(annotations=_READ_ONLY)
 def search_docs(
     query: str,
     version: str | None = None,
@@ -207,6 +209,7 @@ def search_docs(
     )
 
 
+@mcp.tool(annotations=_READ_ONLY)
 def get_doc_section(location: str, version: str | None = None, max_length: int = 8000) -> GetDocSectionResult:
     """Retrieve the full content of a documentation section by location.
 
@@ -242,16 +245,3 @@ def get_doc_section(location: str, version: str | None = None, max_length: int =
 
     msg = f"Documentation section not found: '{location}'. Use search_docs to find valid locations."
     raise ToolError(msg)
-
-
-_TOOL_REGISTRY = [
-    (lookup_documentation, _READ_ONLY),
-    (search_docs, _READ_ONLY),
-    (get_doc_section, _READ_ONLY),
-]
-
-
-def register(mcp: FastMCP) -> None:
-    """Register documentation tools on the MCP server."""
-    for func, hints in _TOOL_REGISTRY:
-        mcp.tool(annotations=hints)(func)

--- a/src/idfkit_mcp/tools/read.py
+++ b/src/idfkit_mcp/tools/read.py
@@ -5,10 +5,10 @@ from __future__ import annotations
 import logging
 from typing import Any, cast
 
-from fastmcp import FastMCP
 from fastmcp.exceptions import ToolError
 from mcp.types import ToolAnnotations
 
+from idfkit_mcp.app import mcp
 from idfkit_mcp.models import (
     ConvertOsmResult,
     GroupSummary,
@@ -27,6 +27,7 @@ _READ_ONLY = ToolAnnotations(readOnlyHint=True, destructiveHint=False, idempoten
 _LOAD = ToolAnnotations(readOnlyHint=False, destructiveHint=False, idempotentHint=True, openWorldHint=False)
 
 
+@mcp.tool(annotations=_LOAD)
 def load_model(file_path: str, version: str | None = None) -> ModelSummary:
     """Open an existing IDF or epJSON file as the active model.
 
@@ -63,6 +64,7 @@ def load_model(file_path: str, version: str | None = None) -> ModelSummary:
     return _build_summary(doc, state)
 
 
+@mcp.tool(annotations=_LOAD)
 def convert_osm_to_idf(
     osm_path: str,
     output_path: str,
@@ -159,6 +161,7 @@ def convert_osm_to_idf(
     )
 
 
+@mcp.tool(annotations=_READ_ONLY)
 def get_model_summary() -> ModelSummary:
     """Get a summary of the currently loaded model.
 
@@ -170,6 +173,7 @@ def get_model_summary() -> ModelSummary:
     return _build_summary(doc, state)
 
 
+@mcp.tool(annotations=_READ_ONLY)
 def list_objects(object_type: str, limit: int = 50) -> ListObjectsResult:
     """List objects of a given type from the loaded model.
 
@@ -196,6 +200,7 @@ def list_objects(object_type: str, limit: int = 50) -> ListObjectsResult:
     return ListObjectsResult(object_type=object_type, total=total, returned=len(objects), objects=objects)
 
 
+@mcp.tool(annotations=_READ_ONLY, output_schema=None)
 def get_object(object_type: str, name: str) -> dict[str, Any]:
     """Get all field values for a specific object.
 
@@ -211,6 +216,7 @@ def get_object(object_type: str, name: str) -> dict[str, Any]:
     return serialize_object(obj)
 
 
+@mcp.tool(annotations=_READ_ONLY)
 def search_objects(query: str, object_type: str | None = None, limit: int = 20) -> SearchObjectsResult:
     """Search for objects by name or field values.
 
@@ -240,6 +246,7 @@ def search_objects(query: str, object_type: str | None = None, limit: int = 20) 
     return SearchObjectsResult.model_validate({"query": query, "count": len(matches), "matches": matches})
 
 
+@mcp.tool(annotations=_READ_ONLY)
 def get_references(name: str) -> ReferencesResult:
     """Get bidirectional references for an object name.
 
@@ -270,34 +277,6 @@ def get_references(name: str) -> ReferencesResult:
         "references": references,
         "references_count": len(references),
     })
-
-
-# ---------------------------------------------------------------------------
-# Tool registry - ``structured_output`` is enabled for tools whose return
-# type is a Pydantic model.  ``get_object`` returns a dynamic dict and
-# therefore stays unstructured.
-# ---------------------------------------------------------------------------
-
-_STRUCTURED_TOOLS = [
-    (load_model, _LOAD),
-    (convert_osm_to_idf, _LOAD),
-    (get_model_summary, _READ_ONLY),
-    (list_objects, _READ_ONLY),
-    (search_objects, _READ_ONLY),
-    (get_references, _READ_ONLY),
-]
-
-_UNSTRUCTURED_TOOLS = [
-    (get_object, _READ_ONLY),
-]
-
-
-def register(mcp: FastMCP) -> None:
-    """Register read tools on the MCP server."""
-    for func, hints in _STRUCTURED_TOOLS:
-        mcp.tool(annotations=hints)(func)
-    for func, hints in _UNSTRUCTURED_TOOLS:
-        mcp.tool(annotations=hints, output_schema=None)(func)
 
 
 def _build_summary(doc: Any, state: Any) -> ModelSummary:

--- a/src/idfkit_mcp/tools/schema.py
+++ b/src/idfkit_mcp/tools/schema.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 import logging
 
-from fastmcp import FastMCP
 from mcp.types import ToolAnnotations
 
+from idfkit_mcp.app import mcp
 from idfkit_mcp.errors import tool_error
 from idfkit_mcp.models import (
     AvailableReferencesResult,
@@ -34,6 +34,7 @@ def _parse_version(version: str | None) -> tuple[int, int, int] | None:
     return (int(parts[0]), int(parts[1]), int(parts[2]))
 
 
+@mcp.tool(annotations=_READ_ONLY)
 def list_object_types(group: str | None = None, version: str | None = None, limit: int = 50) -> ListObjectTypesResult:
     """Discover available EnergyPlus object types, optionally filtered by group.
 
@@ -74,6 +75,7 @@ def list_object_types(group: str | None = None, version: str | None = None, limi
     return ListObjectTypesResult(total_types=total_types, truncated=truncated, groups=groups_result)
 
 
+@mcp.tool(annotations=_READ_ONLY)
 def describe_object_type(object_type: str, version: str | None = None) -> DescribeObjectTypeResult:
     """Get the full field schema for an EnergyPlus object type.
 
@@ -100,6 +102,7 @@ def describe_object_type(object_type: str, version: str | None = None) -> Descri
     return DescribeObjectTypeResult.model_validate(data)
 
 
+@mcp.tool(annotations=_READ_ONLY)
 def search_schema(query: str, version: str | None = None, limit: int = 50) -> SearchSchemaResult:
     """Search for EnergyPlus object types by name or description.
 
@@ -144,6 +147,7 @@ def search_schema(query: str, version: str | None = None, limit: int = 50) -> Se
     })
 
 
+@mcp.tool(annotations=_READ_ONLY)
 def get_available_references(object_type: str, field_name: str) -> AvailableReferencesResult:
     """Get valid object names for a reference field from the loaded model.
 
@@ -202,15 +206,3 @@ def _get_doc_url(
 
 
 # Annotations are defined after functions to avoid forward-reference errors.
-_TOOL_REGISTRY = [
-    (list_object_types, _READ_ONLY),
-    (describe_object_type, _READ_ONLY),
-    (search_schema, _READ_ONLY),
-    (get_available_references, _READ_ONLY),
-]
-
-
-def register(mcp: FastMCP) -> None:
-    """Register schema tools on the MCP server."""
-    for func, hints in _TOOL_REGISTRY:
-        mcp.tool(annotations=hints)(func)

--- a/src/idfkit_mcp/tools/simulation.py
+++ b/src/idfkit_mcp/tools/simulation.py
@@ -6,10 +6,11 @@ import logging
 from sqlite3 import OperationalError
 from typing import Any, Literal
 
-from fastmcp import Context, FastMCP
+from fastmcp import Context
 from fastmcp.exceptions import ToolError
 from mcp.types import ToolAnnotations
 
+from idfkit_mcp.app import mcp
 from idfkit_mcp.models import (
     ExportTimeseriesResult,
     GetResultsSummaryResult,
@@ -30,7 +31,7 @@ ReportingFrequency = Literal["Timestep", "Hourly", "Daily", "Monthly", "RunPerio
 
 
 def _resolve_weather_path(weather_file: str | None, design_day: bool) -> str | None:
-    """Resolve the weather path from arguments or saved session state."""
+    """Resolve the weather file path from arguments or saved session state."""
     from pathlib import Path
 
     state = get_state()
@@ -65,6 +66,20 @@ def _serialize_simulation_errors(errors: Any) -> dict[str, Any]:
     return error_detail
 
 
+def _build_progress_handler(ctx: Context | None) -> Any:
+    """Build an async progress callback for FastMCP context reporting."""
+    from idfkit.simulation.progress import SimulationProgress
+
+    async def on_progress(event: SimulationProgress) -> None:
+        if ctx is not None and event.percent is not None:
+            await ctx.report_progress(progress=event.percent, total=100.0)
+        if ctx is not None:
+            await ctx.info(f"[{event.phase}] {event.message}")
+
+    return on_progress
+
+
+@mcp.tool(annotations=_RUN)
 async def run_simulation(
     weather_file: str | None = None,
     design_day: bool = False,
@@ -88,7 +103,6 @@ async def run_simulation(
     """
     from idfkit.simulation import async_simulate
     from idfkit.simulation.config import find_energyplus
-    from idfkit.simulation.progress import SimulationProgress
 
     state = get_state()
     doc = state.require_model()
@@ -103,12 +117,6 @@ async def run_simulation(
         annual,
     )
 
-    async def on_progress(event: SimulationProgress) -> None:
-        if ctx is not None and event.percent is not None:
-            await ctx.report_progress(progress=event.percent, total=100.0)
-        if ctx is not None:
-            await ctx.info(f"[{event.phase}] {event.message!s}")
-
     result = await async_simulate(
         doc,
         weather="" if weather is None else weather,
@@ -116,7 +124,7 @@ async def run_simulation(
         annual=annual,
         energyplus=config,
         output_dir=output_directory,
-        on_progress=on_progress,
+        on_progress=_build_progress_handler(ctx),
     )
 
     state.simulation_result = result
@@ -143,6 +151,7 @@ async def run_simulation(
     })
 
 
+@mcp.tool(annotations=_READ_ONLY)
 def get_results_summary() -> GetResultsSummaryResult:
     """Get a summary of the last simulation results.
 
@@ -191,6 +200,7 @@ def get_results_summary() -> GetResultsSummaryResult:
     return GetResultsSummaryResult.model_validate(summary)
 
 
+@mcp.tool(annotations=_READ_ONLY)
 def list_output_variables(search: str | None = None, limit: int = 50) -> ListOutputVariablesResult:
     """List available output variables from the last simulation.
 
@@ -232,6 +242,7 @@ def list_output_variables(search: str | None = None, limit: int = 50) -> ListOut
     })
 
 
+@mcp.tool(annotations=_READ_ONLY)
 def query_timeseries(
     variable_name: str,
     key_value: str = "*",
@@ -297,6 +308,7 @@ def query_timeseries(
     })
 
 
+@mcp.tool(annotations=_EXPORT)
 def export_timeseries(
     variable_name: str,
     key_value: str = "*",
@@ -361,19 +373,3 @@ def export_timeseries(
         frequency=ts.frequency,
         rows=len(ts.values),
     )
-
-
-# Annotations are defined after functions to avoid forward-reference errors.
-_TOOL_REGISTRY = [
-    (run_simulation, _RUN),
-    (get_results_summary, _READ_ONLY),
-    (list_output_variables, _READ_ONLY),
-    (query_timeseries, _READ_ONLY),
-    (export_timeseries, _EXPORT),
-]
-
-
-def register(mcp: FastMCP) -> None:
-    """Register simulation tools on the MCP server."""
-    for func, hints in _TOOL_REGISTRY:
-        mcp.tool(annotations=hints)(func)

--- a/src/idfkit_mcp/tools/validation.py
+++ b/src/idfkit_mcp/tools/validation.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 import logging
 
-from fastmcp import FastMCP
 from mcp.types import ToolAnnotations
 
+from idfkit_mcp.app import mcp
 from idfkit_mcp.models import CheckReferencesResult, ValidationResult
 from idfkit_mcp.serializers import serialize_validation_result
 from idfkit_mcp.state import get_state
@@ -16,6 +16,7 @@ logger = logging.getLogger(__name__)
 _READ_ONLY = ToolAnnotations(readOnlyHint=True, destructiveHint=False, idempotentHint=True, openWorldHint=False)
 
 
+@mcp.tool(annotations=_READ_ONLY)
 def validate_model(object_types: list[str] | None = None, check_references: bool = True) -> ValidationResult:
     """Validate the loaded model against the EnergyPlus schema.
 
@@ -41,6 +42,7 @@ def validate_model(object_types: list[str] | None = None, check_references: bool
     return ValidationResult.model_validate(data)
 
 
+@mcp.tool(annotations=_READ_ONLY)
 def check_references(limit: int = 100) -> CheckReferencesResult:
     """Check for dangling references in the loaded model.
 
@@ -78,16 +80,3 @@ def check_references(limit: int = 100) -> CheckReferencesResult:
         "returned": len(limited),
         "dangling_references": limited,
     })
-
-
-# Annotations are defined after functions to avoid forward-reference errors.
-_TOOL_REGISTRY = [
-    (validate_model, _READ_ONLY),
-    (check_references, _READ_ONLY),
-]
-
-
-def register(mcp: FastMCP) -> None:
-    """Register validation tools on the MCP server."""
-    for func, hints in _TOOL_REGISTRY:
-        mcp.tool(annotations=hints)(func)

--- a/src/idfkit_mcp/tools/weather.py
+++ b/src/idfkit_mcp/tools/weather.py
@@ -5,10 +5,10 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from fastmcp import FastMCP
 from fastmcp.exceptions import ToolError
 from mcp.types import ToolAnnotations
 
+from idfkit_mcp.app import mcp
 from idfkit_mcp.models import DownloadWeatherFileResult, SearchWeatherStationsResult
 from idfkit_mcp.serializers import serialize_station
 from idfkit_mcp.state import get_state
@@ -19,6 +19,7 @@ _READ_ONLY_OPEN = ToolAnnotations(readOnlyHint=True, destructiveHint=False, idem
 _DOWNLOAD = ToolAnnotations(readOnlyHint=False, destructiveHint=False, idempotentHint=True, openWorldHint=True)
 
 
+@mcp.tool(annotations=_READ_ONLY_OPEN)
 def search_weather_stations(
     query: str | None = None,
     latitude: float | None = None,
@@ -96,6 +97,7 @@ def _matches_filters(station: Any, country: str | None, state: str | None) -> bo
     return not (state and station.state.upper() != state.upper())
 
 
+@mcp.tool(annotations=_DOWNLOAD)
 def download_weather_file(
     wmo: str | None = None,
     query: str | None = None,
@@ -161,13 +163,3 @@ def download_weather_file(
 
 
 # Annotations are defined after functions to avoid forward-reference errors.
-_TOOL_REGISTRY = [
-    (search_weather_stations, _READ_ONLY_OPEN),
-    (download_weather_file, _DOWNLOAD),
-]
-
-
-def register(mcp: FastMCP) -> None:
-    """Register weather tools on the MCP server."""
-    for func, hints in _TOOL_REGISTRY:
-        mcp.tool(annotations=hints)(func)

--- a/src/idfkit_mcp/tools/write.py
+++ b/src/idfkit_mcp/tools/write.py
@@ -6,10 +6,10 @@ import json
 import logging
 from typing import Any, Literal
 
-from fastmcp import FastMCP
 from fastmcp.exceptions import ToolError
 from mcp.types import ToolAnnotations
 
+from idfkit_mcp.app import mcp
 from idfkit_mcp.models import (
     BatchAddResult,
     ClearSessionResult,
@@ -29,6 +29,7 @@ _DESTRUCTIVE = ToolAnnotations(readOnlyHint=False, destructiveHint=True, idempot
 _SAVE = ToolAnnotations(readOnlyHint=False, destructiveHint=False, idempotentHint=True, openWorldHint=False)
 
 
+@mcp.tool(annotations=_MUTATE)
 def new_model(version: str | None = None) -> NewModelResult:
     """Create a new empty EnergyPlus model.
 
@@ -55,6 +56,7 @@ def new_model(version: str | None = None) -> NewModelResult:
     return NewModelResult(status="created", version=version_string(ver))
 
 
+@mcp.tool(annotations=_MUTATE, output_schema=None)
 def add_object(object_type: str, name: str = "", fields: dict[str, Any] | None = None) -> dict[str, Any]:
     """Add a new object to the model.
 
@@ -75,6 +77,7 @@ def add_object(object_type: str, name: str = "", fields: dict[str, Any] | None =
     return serialize_object(obj)
 
 
+@mcp.tool(annotations=_MUTATE)
 def batch_add_objects(objects: list[dict[str, Any]]) -> BatchAddResult:
     """Add multiple objects to the model in a single call.
 
@@ -116,6 +119,7 @@ def batch_add_objects(objects: list[dict[str, Any]]) -> BatchAddResult:
     return BatchAddResult(total=len(objects), success=success_count, errors=error_count, results=results)
 
 
+@mcp.tool(annotations=_MUTATE, output_schema=None)
 def update_object(object_type: str, name: str, fields: dict[str, Any]) -> dict[str, Any]:
     """Update fields on an existing object.
 
@@ -138,6 +142,7 @@ def update_object(object_type: str, name: str, fields: dict[str, Any]) -> dict[s
     return serialize_object(obj)
 
 
+@mcp.tool(annotations=_DESTRUCTIVE)
 def remove_object(object_type: str, name: str, force: bool = False) -> RemoveObjectResult:
     """Remove an object from the model.
 
@@ -167,6 +172,7 @@ def remove_object(object_type: str, name: str, force: bool = False) -> RemoveObj
     return RemoveObjectResult(status="removed", object_type=object_type, name=obj.name)
 
 
+@mcp.tool(annotations=_MUTATE)
 def rename_object(object_type: str, old_name: str, new_name: str) -> RenameObjectResult:
     """Rename an object and update all references to it.
 
@@ -195,6 +201,7 @@ def rename_object(object_type: str, old_name: str, new_name: str) -> RenameObjec
     )
 
 
+@mcp.tool(annotations=_MUTATE, output_schema=None)
 def duplicate_object(object_type: str, name: str, new_name: str) -> dict[str, Any]:
     """Duplicate an existing object with a new name.
 
@@ -214,6 +221,7 @@ def duplicate_object(object_type: str, name: str, new_name: str) -> dict[str, An
     return serialize_object(obj)
 
 
+@mcp.tool(annotations=_SAVE)
 def save_model(file_path: str | None = None, output_format: Literal["idf", "epjson"] = "idf") -> SaveModelResult:
     """Save the model to a file.
 
@@ -251,6 +259,7 @@ def save_model(file_path: str | None = None, output_format: Literal["idf", "epjs
     return SaveModelResult(status="saved", file_path=str(path), format=output_format)
 
 
+@mcp.tool(annotations=_DESTRUCTIVE)
 def clear_session() -> ClearSessionResult:
     """Clear the persisted session and reset all state.
 
@@ -266,26 +275,3 @@ def clear_session() -> ClearSessionResult:
 # Tool registry - tools returning dynamic EnergyPlus objects stay
 # unstructured; all others get ``structured_output=True``.
 # ---------------------------------------------------------------------------
-
-_STRUCTURED_TOOLS = [
-    (new_model, _MUTATE),
-    (batch_add_objects, _MUTATE),
-    (remove_object, _DESTRUCTIVE),
-    (rename_object, _MUTATE),
-    (save_model, _SAVE),
-    (clear_session, _DESTRUCTIVE),
-]
-
-_UNSTRUCTURED_TOOLS = [
-    (add_object, _MUTATE),
-    (update_object, _MUTATE),
-    (duplicate_object, _MUTATE),
-]
-
-
-def register(mcp: FastMCP) -> None:
-    """Register write tools on the MCP server."""
-    for func, hints in _STRUCTURED_TOOLS:
-        mcp.tool(annotations=hints)(func)
-    for func, hints in _UNSTRUCTURED_TOOLS:
-        mcp.tool(annotations=hints, output_schema=None)(func)


### PR DESCRIPTION
## Summary
- add a shared FastMCP app singleton
- register tools declaratively with @mcp.tool
- remove the old register functions and tool registries

## Verification
- make check
- uv run pytest -q
