### PR TITLE
Migrate tests to async MCP Client protocol

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,14 +2,22 @@
 
 from __future__ import annotations
 
+import json
 import sqlite3
+from collections.abc import AsyncIterator
 from pathlib import Path
+from typing import Any, TypeVar
 
 import pytest
+from fastmcp import Client
+from fastmcp.client.transports import FastMCPTransport
 from idfkit import new_document
 from idfkit.simulation.result import SimulationResult
+from pydantic import BaseModel
 
 from idfkit_mcp.state import ServerState, get_state, reset_sessions
+
+T = TypeVar("T", bound=BaseModel)
 
 
 @pytest.fixture(autouse=True)
@@ -18,6 +26,15 @@ def _reset_state() -> None:
     reset_sessions()
     state = get_state()
     state.persistence_enabled = False
+
+
+@pytest.fixture()
+async def client() -> AsyncIterator[Client[FastMCPTransport]]:
+    """Yield an in-memory FastMCP client bound to the test server."""
+    from idfkit_mcp.server import mcp
+
+    async with Client(transport=mcp) as test_client:
+        yield test_client
 
 
 @pytest.fixture()
@@ -110,3 +127,39 @@ def state_with_sql_only_simulation(tmp_path: Path) -> ServerState:
         runtime_seconds=0.1,
     )
     return state
+
+
+async def call_tool(
+    client: Client[FastMCPTransport],
+    name: str,
+    arguments: dict[str, Any] | None = None,
+    model: type[T] | None = None,
+) -> T | dict[str, Any] | list[Any] | str:
+    """Call a tool over the MCP protocol and decode the result payload."""
+    result = await client.call_tool(name, arguments or {})
+    data: Any = result.structured_content
+
+    if data is None:
+        text_parts = [part.text for part in result.content if hasattr(part, "text")]
+        if len(text_parts) == 1:
+            try:
+                data = json.loads(text_parts[0])
+            except json.JSONDecodeError:
+                data = text_parts[0]
+        else:
+            data = text_parts
+
+    if model is None:
+        return data
+    if isinstance(data, str):
+        return model.model_validate_json(data)
+    return model.model_validate(data)
+
+
+async def read_resource_json(client: Client, uri: str) -> dict[str, Any]:
+    """Read a JSON resource over MCP and decode the first text part."""
+    contents = await client.read_resource(uri)
+    if not contents:
+        msg = f"Resource returned no content: {uri}"
+        raise AssertionError(msg)
+    return json.loads(contents[0].text)

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2,97 +2,99 @@
 
 from __future__ import annotations
 
-from tests.tool_helpers import get_tool_sync
+from fastmcp.client import Client
+from fastmcp.client.transports import FastMCPTransport
 
-
-def _tool(name: str):
-    from idfkit_mcp.server import mcp
-
-    return get_tool_sync(mcp, name)
+from idfkit_mcp.models import (
+    BatchAddResult,
+    CheckReferencesResult,
+    DescribeObjectTypeResult,
+    ListObjectsResult,
+    ModelSummary,
+    NewModelResult,
+    RemoveObjectResult,
+    RenameObjectResult,
+    SaveModelResult,
+    SearchObjectsResult,
+    ValidationResult,
+)
+from tests.conftest import call_tool
 
 
 class TestCreateEditValidateSave:
     """Full workflow: create model → add objects → validate → save."""
 
-    def test_full_workflow(self, tmp_path: object) -> None:
+    async def test_full_workflow(self, client: Client[FastMCPTransport], tmp_path: object) -> None:
         import tempfile
 
-        # 1. Create new model
-        result = _tool("new_model").fn()
+        result = await call_tool(client, "new_model", model=NewModelResult)
         assert result.status == "created"
 
-        # 2. Describe Zone type before creating
-        desc = _tool("describe_object_type").fn(object_type="Zone")
+        desc = await call_tool(client, "describe_object_type", {"object_type": "Zone"}, DescribeObjectTypeResult)
         assert desc.object_type == "Zone"
 
-        # 3. Batch add objects
         objects = [
             {"object_type": "Zone", "name": "Office"},
             {"object_type": "Zone", "name": "Corridor"},
             {"object_type": "Zone", "name": "Storage"},
         ]
-        batch_result = _tool("batch_add_objects").fn(objects=objects)
+        batch_result = await call_tool(client, "batch_add_objects", {"objects": objects}, BatchAddResult)
         assert batch_result.success == 3
 
-        # 4. Get model summary
-        summary = _tool("get_model_summary").fn()
+        summary = await call_tool(client, "get_model_summary", model=ModelSummary)
         assert summary.zone_count == 3
         assert summary.total_objects >= 3
 
-        # 5. List zones
-        zones = _tool("list_objects").fn(object_type="Zone")
+        zones = await call_tool(client, "list_objects", {"object_type": "Zone"}, ListObjectsResult)
         assert zones.total == 3
 
-        # 6. Update a zone
-        updated = _tool("update_object").fn(object_type="Zone", name="Office", fields={"x_origin": 10.0})
+        updated = await call_tool(
+            client, "update_object", {"object_type": "Zone", "name": "Office", "fields": {"x_origin": 10.0}}
+        )
         assert "x_origin" in updated
 
-        # 7. Search for objects
-        search = _tool("search_objects").fn(query="Office")
+        search = await call_tool(client, "search_objects", {"query": "Office"}, SearchObjectsResult)
         assert search.count >= 1
 
-        # 8. Validate
-        validation = _tool("validate_model").fn()
+        validation = await call_tool(client, "validate_model", model=ValidationResult)
         assert validation.is_valid is True
 
-        # 9. Check references
-        refs = _tool("check_references").fn()
+        refs = await call_tool(client, "check_references", model=CheckReferencesResult)
         assert refs.dangling_count is not None
 
-        # 10. Save
         with tempfile.NamedTemporaryFile(suffix=".idf", delete=False) as f:
-            save_result = _tool("save_model").fn(file_path=f.name)
+            save_result = await call_tool(client, "save_model", {"file_path": f.name}, SaveModelResult)
         assert save_result.status == "saved"
 
-        # 11. Load it back
-        load_result = _tool("load_model").fn(file_path=f.name)
+        load_result = await call_tool(client, "load_model", {"file_path": f.name}, ModelSummary)
         assert load_result.zone_count == 3
 
-    def test_rename_and_duplicate(self) -> None:
-        # Create model with zones
-        _tool("new_model").fn()
-        _tool("add_object").fn(object_type="Zone", name="ZoneA")
+    async def test_rename_and_duplicate(self, client: object) -> None:
+        await call_tool(client, "new_model", model=NewModelResult)
+        await call_tool(client, "add_object", {"object_type": "Zone", "name": "ZoneA"})
 
-        # Duplicate
-        dup = _tool("duplicate_object").fn(object_type="Zone", name="ZoneA", new_name="ZoneB")
+        dup = await call_tool(client, "duplicate_object", {"object_type": "Zone", "name": "ZoneA", "new_name": "ZoneB"})
         assert dup["name"] == "ZoneB"
 
-        # Rename
-        renamed = _tool("rename_object").fn(object_type="Zone", old_name="ZoneA", new_name="ZoneC")
+        renamed = await call_tool(
+            client,
+            "rename_object",
+            {"object_type": "Zone", "old_name": "ZoneA", "new_name": "ZoneC"},
+            RenameObjectResult,
+        )
         assert renamed.status == "renamed"
 
-        # Verify
-        summary = _tool("get_model_summary").fn()
+        summary = await call_tool(client, "get_model_summary", model=ModelSummary)
         assert summary.zone_count == 2
 
-    def test_remove_workflow(self) -> None:
-        _tool("new_model").fn()
-        _tool("add_object").fn(object_type="Zone", name="TempZone")
+    async def test_remove_workflow(self, client: object) -> None:
+        await call_tool(client, "new_model", model=NewModelResult)
+        await call_tool(client, "add_object", {"object_type": "Zone", "name": "TempZone"})
 
-        # Remove
-        result = _tool("remove_object").fn(object_type="Zone", name="TempZone")
+        result = await call_tool(
+            client, "remove_object", {"object_type": "Zone", "name": "TempZone"}, RemoveObjectResult
+        )
         assert result.status == "removed"
 
-        # Verify empty
-        summary = _tool("get_model_summary").fn()
+        summary = await call_tool(client, "get_model_summary", model=ModelSummary)
         assert summary.zone_count == 0

--- a/tests/test_read_tools.py
+++ b/tests/test_read_tools.py
@@ -13,25 +13,20 @@ import pytest
 from fastmcp.exceptions import ToolError
 from idfkit import new_document, write_idf
 
+from idfkit_mcp.models import ConvertOsmResult, ListObjectsResult, ModelSummary, ReferencesResult, SearchObjectsResult
 from idfkit_mcp.state import ServerState, get_state
-from tests.tool_helpers import get_tool_sync
-
-
-def _tool(name: str):
-    from idfkit_mcp.server import mcp
-
-    return get_tool_sync(mcp, name)
+from tests.conftest import call_tool
 
 
 class TestLoadModel:
-    def test_load_idf(self) -> None:
+    async def test_load_idf(self, client: object) -> None:
         doc = new_document()
         doc.add("Zone", "TestZone")
         with tempfile.NamedTemporaryFile(suffix=".idf", delete=False) as f:
             write_idf(doc, f.name)
             path = f.name
 
-        result = _tool("load_model").fn(file_path=path)
+        result = await call_tool(client, "load_model", {"file_path": path}, ModelSummary)
         assert result.total_objects >= 1
         assert result.zone_count == 1
 
@@ -39,42 +34,42 @@ class TestLoadModel:
         assert state.document is not None
         assert state.file_path == Path(path)
 
-    def test_load_nonexistent(self) -> None:
+    async def test_load_nonexistent(self, client: object) -> None:
         with pytest.raises(ToolError):
-            _tool("load_model").fn(file_path="/nonexistent/file.idf")
+            await call_tool(client, "load_model", {"file_path": "/nonexistent/file.idf"})
 
 
 class TestGetModelSummary:
-    def test_without_model(self) -> None:
+    async def test_without_model(self, client: object) -> None:
         with pytest.raises(ToolError):
-            _tool("get_model_summary").fn()
+            await call_tool(client, "get_model_summary")
 
-    def test_with_model(self, state_with_zones: ServerState) -> None:
-        result = _tool("get_model_summary").fn()
+    async def test_with_model(self, client: object, state_with_zones: ServerState) -> None:
+        result = await call_tool(client, "get_model_summary", model=ModelSummary)
         assert result.zone_count == 2
-        assert result.total_objects >= 3  # 2 zones + 1 surface + defaults
+        assert result.total_objects >= 3
 
 
 class TestListObjects:
-    def test_without_model(self) -> None:
+    async def test_without_model(self, client: object) -> None:
         with pytest.raises(ToolError):
-            _tool("list_objects").fn(object_type="Zone")
+            await call_tool(client, "list_objects", {"object_type": "Zone"})
 
-    def test_list_zones(self, state_with_zones: ServerState) -> None:
-        result = _tool("list_objects").fn(object_type="Zone")
+    async def test_list_zones(self, client: object, state_with_zones: ServerState) -> None:
+        result = await call_tool(client, "list_objects", {"object_type": "Zone"}, ListObjectsResult)
         assert result.total == 2
         names = [o["name"] for o in result.objects]
         assert "Office" in names
         assert "Corridor" in names
 
-    def test_missing_type(self, state_with_zones: ServerState) -> None:
+    async def test_missing_type(self, client: object, state_with_zones: ServerState) -> None:
         with pytest.raises(ToolError):
-            _tool("list_objects").fn(object_type="Material")
+            await call_tool(client, "list_objects", {"object_type": "Material"})
 
 
 class TestGetObject:
-    def test_get_zone(self, state_with_zones: ServerState) -> None:
-        result = _tool("get_object").fn(object_type="Zone", name="Office")
+    async def test_get_zone(self, client: object, state_with_zones: ServerState) -> None:
+        result = await call_tool(client, "get_object", {"object_type": "Zone", "name": "Office"})
         assert result["name"] == "Office"
         assert result["object_type"] == "Zone"
         assert "x_origin" in result
@@ -82,58 +77,63 @@ class TestGetObject:
         assert "z_origin" in result
         assert result["x_origin"] is None
 
-    def test_missing_object(self, state_with_zones: ServerState) -> None:
+    async def test_missing_object(self, client: object, state_with_zones: ServerState) -> None:
         with pytest.raises(ToolError):
-            _tool("get_object").fn(object_type="Zone", name="Nonexistent")
+            await call_tool(client, "get_object", {"object_type": "Zone", "name": "Nonexistent"})
 
 
 class TestGetObjectSingleton:
     """Singleton types (no name field) should be retrievable."""
 
-    def test_get_singleton_with_empty_name(self, state_with_singletons: ServerState) -> None:
-        result = _tool("get_object").fn(object_type="SimulationControl", name="")
+    async def test_get_singleton_with_empty_name(self, client: object, state_with_singletons: ServerState) -> None:
+        result = await call_tool(client, "get_object", {"object_type": "SimulationControl", "name": ""})
         assert result["object_type"] == "SimulationControl"
 
-    def test_get_singleton_with_any_name(self, state_with_singletons: ServerState) -> None:
-        # AI clients often pass the type name as the name — should still work
-        result = _tool("get_object").fn(object_type="SimulationControl", name="SimulationControl")
+    async def test_get_singleton_with_any_name(self, client: object, state_with_singletons: ServerState) -> None:
+        result = await call_tool(
+            client, "get_object", {"object_type": "SimulationControl", "name": "SimulationControl"}
+        )
         assert result["object_type"] == "SimulationControl"
 
-    def test_get_singleton_global_geometry_rules(self, state_with_singletons: ServerState) -> None:
-        result = _tool("get_object").fn(object_type="GlobalGeometryRules", name="")
+    async def test_get_singleton_global_geometry_rules(
+        self, client: object, state_with_singletons: ServerState
+    ) -> None:
+        result = await call_tool(client, "get_object", {"object_type": "GlobalGeometryRules", "name": ""})
         assert result["object_type"] == "GlobalGeometryRules"
 
 
 class TestSearchObjects:
-    def test_search_by_name(self, state_with_zones: ServerState) -> None:
-        result = _tool("search_objects").fn(query="Office")
+    async def test_search_by_name(self, client: object, state_with_zones: ServerState) -> None:
+        result = await call_tool(client, "search_objects", {"query": "Office"}, SearchObjectsResult)
         assert result.count >= 1
         types = [m.object_type for m in result.matches]
         assert "Zone" in types
 
-    def test_search_by_type(self, state_with_zones: ServerState) -> None:
-        result = _tool("search_objects").fn(query="Office", object_type="Zone")
+    async def test_search_by_type(self, client: object, state_with_zones: ServerState) -> None:
+        result = await call_tool(
+            client, "search_objects", {"query": "Office", "object_type": "Zone"}, SearchObjectsResult
+        )
         assert result.count == 1
 
-    def test_no_results(self, state_with_zones: ServerState) -> None:
-        result = _tool("search_objects").fn(query="xyznonexistent")
+    async def test_no_results(self, client: object, state_with_zones: ServerState) -> None:
+        result = await call_tool(client, "search_objects", {"query": "xyznonexistent"}, SearchObjectsResult)
         assert result.count == 0
 
 
 class TestGetReferences:
-    def test_referenced_zone(self, state_with_zones: ServerState) -> None:
-        result = _tool("get_references").fn(name="Office")
+    async def test_referenced_zone(self, client: object, state_with_zones: ServerState) -> None:
+        result = await call_tool(client, "get_references", {"name": "Office"}, ReferencesResult)
         assert result.referenced_by_count >= 1
         ref_types = [r.object_type for r in result.referenced_by]
         assert "BuildingSurface:Detailed" in ref_types
 
-    def test_unreferenced(self, state_with_zones: ServerState) -> None:
-        result = _tool("get_references").fn(name="Corridor")
+    async def test_unreferenced(self, client: object, state_with_zones: ServerState) -> None:
+        result = await call_tool(client, "get_references", {"name": "Corridor"}, ReferencesResult)
         assert result.referenced_by_count == 0
 
 
 class TestConvertOsmToIdf:
-    def test_missing_openstudio(self, tmp_path: Path) -> None:
+    async def test_missing_openstudio(self, client: object, tmp_path: Path) -> None:
         osm_path = tmp_path / "input.osm"
         osm_path.write_text("OSM")
         output_path = tmp_path / "out.idf"
@@ -147,20 +147,18 @@ class TestConvertOsmToIdf:
             return original_import(name, *args, **kwargs)
 
         with patch("builtins.__import__", side_effect=_import), pytest.raises(ToolError, match="OpenStudio"):
-            _tool("convert_osm_to_idf").fn(
-                osm_path=str(osm_path),
-                output_path=str(output_path),
-            )
+            await call_tool(client, "convert_osm_to_idf", {"osm_path": str(osm_path), "output_path": str(output_path)})
 
-    def test_missing_input_file(self, tmp_path: Path) -> None:
+    async def test_missing_input_file(self, client: object, tmp_path: Path) -> None:
         fake_openstudio = _fake_openstudio_module()
         with patch.dict(sys.modules, {"openstudio": fake_openstudio}), pytest.raises(ToolError, match="not found"):
-            _tool("convert_osm_to_idf").fn(
-                osm_path=str(tmp_path / "missing.osm"),
-                output_path=str(tmp_path / "out.idf"),
+            await call_tool(
+                client,
+                "convert_osm_to_idf",
+                {"osm_path": str(tmp_path / "missing.osm"), "output_path": str(tmp_path / "out.idf")},
             )
 
-    def test_invalid_extensions(self, tmp_path: Path) -> None:
+    async def test_invalid_extensions(self, client: object, tmp_path: Path) -> None:
         fake_openstudio = _fake_openstudio_module()
         bad_input = tmp_path / "input.txt"
         bad_input.write_text("not osm")
@@ -168,17 +166,17 @@ class TestConvertOsmToIdf:
         good_input.write_text("osm")
         with patch.dict(sys.modules, {"openstudio": fake_openstudio}):
             with pytest.raises(ToolError, match=r"\.osm"):
-                _tool("convert_osm_to_idf").fn(
-                    osm_path=str(bad_input),
-                    output_path=str(tmp_path / "out.idf"),
+                await call_tool(
+                    client, "convert_osm_to_idf", {"osm_path": str(bad_input), "output_path": str(tmp_path / "out.idf")}
                 )
             with pytest.raises(ToolError, match=r"\.idf"):
-                _tool("convert_osm_to_idf").fn(
-                    osm_path=str(good_input),
-                    output_path=str(tmp_path / "out.txt"),
+                await call_tool(
+                    client,
+                    "convert_osm_to_idf",
+                    {"osm_path": str(good_input), "output_path": str(tmp_path / "out.txt")},
                 )
 
-    def test_output_exists_requires_overwrite(self, tmp_path: Path) -> None:
+    async def test_output_exists_requires_overwrite(self, client: object, tmp_path: Path) -> None:
         fake_openstudio = _fake_openstudio_module()
         osm_path = tmp_path / "input.osm"
         osm_path.write_text("OSM")
@@ -186,13 +184,13 @@ class TestConvertOsmToIdf:
         output_path.write_text("existing")
 
         with patch.dict(sys.modules, {"openstudio": fake_openstudio}), pytest.raises(ToolError, match="overwrite=True"):
-            _tool("convert_osm_to_idf").fn(
-                osm_path=str(osm_path),
-                output_path=str(output_path),
-                overwrite=False,
+            await call_tool(
+                client,
+                "convert_osm_to_idf",
+                {"osm_path": str(osm_path), "output_path": str(output_path), "overwrite": False},
             )
 
-    def test_successful_conversion_loads_state(self, tmp_path: Path) -> None:
+    async def test_successful_conversion_loads_state(self, client: object, tmp_path: Path) -> None:
         fake_openstudio = _fake_openstudio_module()
         osm_path = tmp_path / "input.osm"
         osm_path.write_text("OSM")
@@ -202,11 +200,16 @@ class TestConvertOsmToIdf:
         doc.add("Zone", "ConvertedZone")
 
         with patch.dict(sys.modules, {"openstudio": fake_openstudio}), patch("idfkit.load_idf", return_value=doc):
-            result = _tool("convert_osm_to_idf").fn(
-                osm_path=str(osm_path),
-                output_path=str(output_path),
-                allow_newer_versions=True,
-                overwrite=False,
+            result = await call_tool(
+                client,
+                "convert_osm_to_idf",
+                {
+                    "osm_path": str(osm_path),
+                    "output_path": str(output_path),
+                    "allow_newer_versions": True,
+                    "overwrite": False,
+                },
+                ConvertOsmResult,
             )
 
         assert result.status == "converted"

--- a/tests/test_schema_tools.py
+++ b/tests/test_schema_tools.py
@@ -5,8 +5,14 @@ from __future__ import annotations
 import pytest
 from fastmcp.exceptions import ToolError
 
+from idfkit_mcp.models import (
+    AvailableReferencesResult,
+    DescribeObjectTypeResult,
+    ListObjectTypesResult,
+    SearchSchemaResult,
+)
 from idfkit_mcp.tools.schema import _parse_version
-from tests.tool_helpers import get_tool_sync
+from tests.conftest import call_tool
 
 
 class TestParseVersion:
@@ -22,135 +28,98 @@ class TestParseVersion:
 
 
 class TestListObjectTypes:
-    def test_returns_groups(self) -> None:
-        from idfkit_mcp.server import mcp
-
-        tool = get_tool_sync(mcp, "list_object_types")
-        result = tool.fn()
+    async def test_returns_groups(self, client: object) -> None:
+        result = await call_tool(client, "list_object_types", model=ListObjectTypesResult)
         assert result.total_types > 0
         assert result.groups
 
-    def test_filter_by_group(self) -> None:
-        from idfkit_mcp.server import mcp
-
-        tool = get_tool_sync(mcp, "list_object_types")
-        result = tool.fn(group="Thermal Zones and Surfaces")
+    async def test_filter_by_group(self, client: object) -> None:
+        result = await call_tool(
+            client, "list_object_types", {"group": "Thermal Zones and Surfaces"}, ListObjectTypesResult
+        )
         assert result.total_types > 0
-        # All returned items should be in the filtered group
         assert "Thermal Zones and Surfaces" in result.groups
 
-    def test_returns_error_for_bad_version(self) -> None:
-        from idfkit_mcp.server import mcp
-
-        tool = get_tool_sync(mcp, "list_object_types")
+    async def test_returns_error_for_bad_version(self, client: object) -> None:
         with pytest.raises(ToolError):
-            tool.fn(version="1.0.0")
+            await call_tool(client, "list_object_types", {"version": "1.0.0"})
 
-    def test_truncated_when_over_limit(self) -> None:
-        from idfkit_mcp.server import mcp
-
-        tool = get_tool_sync(mcp, "list_object_types")
-        result = tool.fn()
+    async def test_truncated_when_over_limit(self, client: object) -> None:
+        result = await call_tool(client, "list_object_types", model=ListObjectTypesResult)
         assert result.truncated is True
-        # Truncated response should have counts but no type lists
         for group_data in result.groups.values():
             assert group_data.count > 0
             assert group_data.types is None
 
-    def test_not_truncated_with_group_filter(self) -> None:
-        from idfkit_mcp.server import mcp
-
-        tool = get_tool_sync(mcp, "list_object_types")
-        result = tool.fn(group="Thermal Zones and Surfaces")
-        # Group-filtered queries should return type names even if the group
-        # itself exceeds the default top-level discovery limit.
+    async def test_not_truncated_with_group_filter(self, client: object) -> None:
+        result = await call_tool(
+            client, "list_object_types", {"group": "Thermal Zones and Surfaces"}, ListObjectTypesResult
+        )
         assert result.truncated is False
         for group_data in result.groups.values():
             assert group_data.types is not None
 
-    def test_high_limit_is_capped(self) -> None:
-        from idfkit_mcp.server import mcp
-
-        tool = get_tool_sync(mcp, "list_object_types")
-        # limit is hard-capped to 100 regardless of caller request
-        result = tool.fn(limit=10000)
+    async def test_high_limit_is_capped(self, client: object) -> None:
+        result = await call_tool(client, "list_object_types", {"limit": 10000}, ListObjectTypesResult)
         assert result.total_types > 100
         assert result.truncated is True
 
 
 class TestDescribeObjectType:
-    def test_zone(self) -> None:
-        from idfkit_mcp.server import mcp
-
-        tool = get_tool_sync(mcp, "describe_object_type")
-        result = tool.fn(object_type="Zone")
+    async def test_zone(self, client: object) -> None:
+        result = await call_tool(client, "describe_object_type", {"object_type": "Zone"}, DescribeObjectTypeResult)
         assert result.object_type == "Zone"
         assert result.has_name is True
         assert len(result.fields) > 0
         field_names = [f.name for f in result.fields]
         assert "x_origin" in field_names
 
-    def test_unknown_type(self) -> None:
-        from idfkit_mcp.server import mcp
-
-        tool = get_tool_sync(mcp, "describe_object_type")
+    async def test_unknown_type(self, client: object) -> None:
         with pytest.raises(ToolError):
-            tool.fn(object_type="NonExistent")
+            await call_tool(client, "describe_object_type", {"object_type": "NonExistent"})
 
 
 class TestSearchSchema:
-    def test_search_zone(self) -> None:
-        from idfkit_mcp.server import mcp
-
-        tool = get_tool_sync(mcp, "search_schema")
-        result = tool.fn(query="Zone")
+    async def test_search_zone(self, client: object) -> None:
+        result = await call_tool(client, "search_schema", {"query": "Zone", "limit": 30}, SearchSchemaResult)
         assert result.count > 0
-        # "Zone" appears in many type names; verify we get zone-related results
-        assert any("Zone" in m.object_type for m in result.matches)
+        types = [m.object_type for m in result.matches]
+        assert "Zone" in types
 
-    def test_search_no_results(self) -> None:
-        from idfkit_mcp.server import mcp
-
-        tool = get_tool_sync(mcp, "search_schema")
-        result = tool.fn(query="xyznonexistent123")
+    async def test_search_no_results(self, client: object) -> None:
+        result = await call_tool(client, "search_schema", {"query": "xyznonexistent123"}, SearchSchemaResult)
         assert result.count == 0
 
-    def test_limit_caps_results(self) -> None:
-        from idfkit_mcp.server import mcp
-
-        tool = get_tool_sync(mcp, "search_schema")
-        result = tool.fn(query="Zone", limit=5)
+    async def test_limit_caps_results(self, client: object) -> None:
+        result = await call_tool(client, "search_schema", {"query": "Zone", "limit": 5}, SearchSchemaResult)
         assert result.count <= 5
         assert len(result.matches) <= 5
         assert result.limit == 5
 
-    def test_default_limit_in_response(self) -> None:
-        from idfkit_mcp.server import mcp
-
-        tool = get_tool_sync(mcp, "search_schema")
-        result = tool.fn(query="Zone")
+    async def test_default_limit_in_response(self, client: object) -> None:
+        result = await call_tool(client, "search_schema", {"query": "Zone"}, SearchSchemaResult)
         assert result.limit == 10
 
 
 class TestGetAvailableReferences:
-    def test_without_model(self) -> None:
-        from idfkit_mcp.server import mcp
-
-        tool = get_tool_sync(mcp, "get_available_references")
+    async def test_without_model(self, client: object) -> None:
         with pytest.raises(ToolError):
-            tool.fn(object_type="BuildingSurface:Detailed", field_name="zone_name")
+            await call_tool(
+                client,
+                "get_available_references",
+                {"object_type": "BuildingSurface:Detailed", "field_name": "zone_name"},
+            )
 
-    def test_with_model(self, state_with_zones: object) -> None:
-        from idfkit_mcp.server import mcp
-
-        tool = get_tool_sync(mcp, "get_available_references")
-        result = tool.fn(object_type="BuildingSurface:Detailed", field_name="zone_name")
+    async def test_with_model(self, client: object, state_with_zones: object) -> None:
+        result = await call_tool(
+            client,
+            "get_available_references",
+            {"object_type": "BuildingSurface:Detailed", "field_name": "zone_name"},
+            AvailableReferencesResult,
+        )
         assert "Office" in result.available_names
         assert "Corridor" in result.available_names
 
-    def test_non_reference_field(self, state_with_model: object) -> None:
-        from idfkit_mcp.server import mcp
-
-        tool = get_tool_sync(mcp, "get_available_references")
+    async def test_non_reference_field(self, client: object, state_with_model: object) -> None:
         with pytest.raises(ToolError):
-            tool.fn(object_type="Zone", field_name="x_origin")
+            await call_tool(client, "get_available_references", {"object_type": "Zone", "field_name": "x_origin"})

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -5,17 +5,18 @@ from __future__ import annotations
 from typing import Any
 
 import pytest
+from fastmcp import Client
 
 from idfkit_mcp.server import _parse_args, mcp
-from tests.tool_helpers import list_tools_sync
+from tests.conftest import read_resource_json
 
 
 class TestCreateServer:
     def test_returns_fastmcp_instance(self) -> None:
         assert mcp.name == "idfkit"
 
-    def test_registers_all_tool_groups(self) -> None:
-        tool_names = set(list_tools_sync(mcp))
+    async def test_registers_all_tool_groups(self, client: Client) -> None:
+        tool_names = {tool.name for tool in await client.list_tools()}
         expected = {
             "list_object_types",
             "describe_object_type",
@@ -47,6 +48,30 @@ class TestCreateServer:
             "download_weather_file",
         }
         assert expected.issubset(tool_names)
+
+    async def test_registers_resources(self, client: Client) -> None:
+        resource_uris = {str(resource.uri) for resource in await client.list_resources()}
+        template_uris = {str(template.uriTemplate) for template in await client.list_resource_templates()}
+
+        assert "idfkit://model/summary" in resource_uris
+        assert "idfkit://simulation/results" in resource_uris
+        assert "idfkit://schema/{object_type}" in template_uris
+        assert "idfkit://model/objects/{object_type}/{name}" in template_uris
+
+    async def test_reads_model_summary_resource(self, client: Client, state_with_zones: object) -> None:
+        payload = await read_resource_json(client, "idfkit://model/summary")
+        assert payload["zone_count"] == 2
+        assert payload["total_objects"] >= 3
+
+    async def test_reads_schema_resource_template(self, client: Client) -> None:
+        payload = await read_resource_json(client, "idfkit://schema/Zone")
+        assert payload["object_type"] == "Zone"
+        assert "fields" in payload
+
+    async def test_reads_object_resource_template(self, client: Client, state_with_zones: object) -> None:
+        payload = await read_resource_json(client, "idfkit://model/objects/Zone/Office")
+        assert payload["object_type"] == "Zone"
+        assert payload["name"] == "Office"
 
 
 class TestParseArgs:
@@ -106,25 +131,25 @@ class TestToolSchemas:
     """Verify that all tool schemas are well-formed for broad client compatibility."""
 
     @pytest.fixture()
-    def tools(self) -> dict[str, Any]:
-        return list_tools_sync(mcp)
+    async def tools(self, client: Client) -> list[Any]:
+        return await client.list_tools()
 
-    def test_all_tools_have_properties_key(self, tools: dict[str, Any]) -> None:
+    async def test_all_tools_have_properties_key(self, tools: list[Any]) -> None:
         """Every tool's inputSchema must include a 'properties' key.
 
         OpenAI's Agents SDK and other strict consumers require this key to be
         present, even for tools with no parameters (where it should be ``{}``).
         """
-        for name, tool in tools.items():
-            schema = tool.parameters
-            assert "properties" in schema, f"Tool '{name}' inputSchema missing 'properties' key: {schema}"
+        for tool in tools:
+            schema = tool.inputSchema
+            assert "properties" in schema, f"Tool '{tool.name}' inputSchema missing 'properties' key: {schema}"
 
-    def test_all_tools_have_annotations(self, tools: dict[str, Any]) -> None:
+    async def test_all_tools_have_annotations(self, tools: list[Any]) -> None:
         """Every tool should have ToolAnnotations set (readOnlyHint, etc.)."""
-        for name, tool in tools.items():
-            assert tool.annotations is not None, f"Tool '{name}' is missing annotations"
+        for tool in tools:
+            assert tool.annotations is not None, f"Tool '{tool.name}' is missing annotations"
 
-    def test_schemas_support_additional_properties_false(self, tools: dict[str, Any]) -> None:
+    async def test_schemas_support_additional_properties_false(self, tools: list[Any]) -> None:
         """Verify schemas can accept additionalProperties: false without conflict.
 
         OpenAI's ``convert_schemas_to_strict`` applies this constraint. Tools
@@ -136,28 +161,27 @@ class TestToolSchemas:
         # constrained to a static schema.
         dynamic_schema_tools = {"add_object", "batch_add_objects", "update_object"}
 
-        for name, tool in tools.items():
-            if name in dynamic_schema_tools:
+        for tool in tools:
+            if tool.name in dynamic_schema_tools:
                 continue
-            schema = tool.parameters
+            schema = tool.inputSchema
             properties = schema.get("properties", {})
             for prop_name, prop_schema in properties.items():
-                # Nested object schemas should not conflict with additionalProperties: false
                 if prop_schema.get("type") == "object" and "properties" not in prop_schema:
                     pytest.fail(
-                        f"Tool '{name}' param '{prop_name}' is an unstructured object "
+                        f"Tool '{tool.name}' param '{prop_name}' is an unstructured object "
                         f"(no 'properties' key) — incompatible with strict mode."
                     )
 
-    def test_structured_output_tools_have_output_schema(self, tools: dict[str, Any]) -> None:
+    async def test_structured_output_tools_have_output_schema(self, tools: list[Any]) -> None:
         """Tools with Pydantic return types must have an output schema defined."""
         # Tools that return dynamic dicts (no Pydantic model) — intentionally unstructured.
         unstructured_tools = {"add_object", "update_object", "duplicate_object", "get_object"}
 
-        for name, tool in tools.items():
-            if name in unstructured_tools:
-                assert tool.output_schema is None, f"Tool '{name}' should be unstructured but has an output schema"
+        for tool in tools:
+            if tool.name in unstructured_tools:
+                assert tool.outputSchema is None, f"Tool '{tool.name}' should be unstructured but has an output schema"
             else:
-                assert tool.output_schema is not None, (
-                    f"Tool '{name}' is missing an output schema — add a Pydantic return type"
+                assert tool.outputSchema is not None, (
+                    f"Tool '{tool.name}' is missing an output schema — add a Pydantic return type"
                 )

--- a/tests/test_session_persistence.py
+++ b/tests/test_session_persistence.py
@@ -9,13 +9,7 @@ import pytest
 from idfkit import new_document, write_idf
 
 from idfkit_mcp.state import get_state
-from tests.tool_helpers import get_tool_sync
-
-
-def _tool(name: str):
-    from idfkit_mcp.server import mcp
-
-    return get_tool_sync(mcp, name)
+from tests.conftest import call_tool
 
 
 @pytest.fixture()
@@ -273,15 +267,14 @@ class TestRequireAutoRestore:
 
 
 class TestNewModelNoSession:
-    def test_new_model_does_not_persist(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    async def test_new_model_does_not_persist(
+        self, client: object, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
         session_file = tmp_path / "session.json"
         monkeypatch.setattr("idfkit_mcp.state._session_file_path", lambda: session_file)
         state = get_state()
         state.persistence_enabled = True
         state._session_restored = False
 
-        # new_model sets file_path=None, so save_session writes no file_path
-        _tool("new_model").fn()
-        # Session might be written by a future save_model, but new_model
-        # doesn't call save_session itself, so no file should exist
+        await call_tool(client, "new_model")
         assert not session_file.exists()

--- a/tests/test_simulation_tools.py
+++ b/tests/test_simulation_tools.py
@@ -7,58 +7,47 @@ from unittest.mock import patch
 import pytest
 from fastmcp.exceptions import ToolError
 
+from idfkit_mcp.models import ListOutputVariablesResult
 from idfkit_mcp.state import ServerState
-from tests.tool_helpers import get_tool_async, get_tool_sync
-
-
-def _tool(name: str):
-    from idfkit_mcp.server import mcp
-
-    return get_tool_sync(mcp, name)
-
-
-async def _async_tool(name: str):
-    from idfkit_mcp.server import mcp
-
-    return await get_tool_async(mcp, name)
+from tests.conftest import call_tool
 
 
 class TestRunSimulation:
-    async def test_no_model(self) -> None:
+    async def test_no_model(self, client: object) -> None:
         with pytest.raises(ToolError):
-            await (await _async_tool("run_simulation")).fn()
+            await call_tool(client, "run_simulation")
 
-    async def test_no_weather(self, state_with_model: ServerState) -> None:
+    async def test_no_weather(self, client: object, state_with_model: ServerState) -> None:
         with pytest.raises(ToolError):
-            await (await _async_tool("run_simulation")).fn()
+            await call_tool(client, "run_simulation")
 
-    async def test_output_directory_accepted(self, state_with_model: ServerState) -> None:
-        """output_directory param is accepted (fails for other reasons, not TypeError)."""
+    async def test_output_directory_accepted(self, client: object, state_with_model: ServerState) -> None:
         with pytest.raises(ToolError, match=r"weather|No weather"):
-            await (await _async_tool("run_simulation")).fn(output_directory="/tmp/test_out")  # noqa: S108
+            await call_tool(client, "run_simulation", {"output_directory": "/tmp/test_out"})  # noqa: S108
 
-    async def test_defaults_to_latest_energyplus(self, state_with_model: ServerState) -> None:
-        """run_simulation lets find_energyplus pick the best version when not specified."""
+    async def test_defaults_to_latest_energyplus(self, client: object, state_with_model: ServerState) -> None:
         with patch("idfkit.simulation.config.find_energyplus") as mock_find:
             mock_find.side_effect = RuntimeError("test stop")
             with pytest.raises(ToolError):
-                await (await _async_tool("run_simulation")).fn(design_day=True)
+                await call_tool(client, "run_simulation", {"design_day": True})
             mock_find.assert_called_once_with(path=None, version=None)
 
 
 class TestGetResultsSummary:
-    def test_no_simulation(self) -> None:
+    async def test_no_simulation(self, client: object) -> None:
         with pytest.raises(ToolError):
-            _tool("get_results_summary").fn()
+            await call_tool(client, "get_results_summary")
 
 
 class TestListOutputVariables:
-    def test_no_simulation(self) -> None:
+    async def test_no_simulation(self, client: object) -> None:
         with pytest.raises(ToolError):
-            _tool("list_output_variables").fn()
+            await call_tool(client, "list_output_variables")
 
-    def test_falls_back_to_sql_when_rdd_and_mdd_are_empty(self, state_with_sql_only_simulation: ServerState) -> None:
-        result = _tool("list_output_variables").fn()
+    async def test_falls_back_to_sql_when_rdd_and_mdd_are_empty(
+        self, client: object, state_with_sql_only_simulation: ServerState
+    ) -> None:
+        result = await call_tool(client, "list_output_variables", model=ListOutputVariablesResult)
         assert result.total_available == 3
         assert result.returned == 3
         assert {item.name for item in result.variables} == {
@@ -67,20 +56,22 @@ class TestListOutputVariables:
             "Electricity:Facility",
         }
 
-    def test_sql_fallback_respects_search(self, state_with_sql_only_simulation: ServerState) -> None:
-        result = _tool("list_output_variables").fn(search="Drybulb")
+    async def test_sql_fallback_respects_search(
+        self, client: object, state_with_sql_only_simulation: ServerState
+    ) -> None:
+        result = await call_tool(client, "list_output_variables", {"search": "Drybulb"}, ListOutputVariablesResult)
         assert result.total_available == 3
         assert result.returned == 1
         assert result.variables[0].name == "Site Outdoor Air Drybulb Temperature"
 
 
 class TestQueryTimeseries:
-    def test_no_simulation(self) -> None:
+    async def test_no_simulation(self, client: object) -> None:
         with pytest.raises(ToolError):
-            _tool("query_timeseries").fn(variable_name="Zone Mean Air Temperature")
+            await call_tool(client, "query_timeseries", {"variable_name": "Zone Mean Air Temperature"})
 
 
 class TestExportTimeseries:
-    def test_no_simulation(self) -> None:
+    async def test_no_simulation(self, client: object) -> None:
         with pytest.raises(ToolError):
-            _tool("export_timeseries").fn(variable_name="Zone Mean Air Temperature")
+            await call_tool(client, "export_timeseries", {"variable_name": "Zone Mean Air Temperature"})

--- a/tests/test_tools_docs.py
+++ b/tests/test_tools_docs.py
@@ -11,15 +11,20 @@ from unittest.mock import patch
 import pytest
 from fastmcp.exceptions import ToolError
 
-from idfkit_mcp.server import mcp
+from idfkit_mcp.models import (
+    DescribeObjectTypeResult,
+    GetDocSectionResult,
+    LookupDocumentationResult,
+    SearchDocsResult,
+    SearchSchemaResult,
+)
 from idfkit_mcp.state import ServerState, get_state
-from tests.tool_helpers import get_tool_sync
+from tests.conftest import call_tool
 
 
 class TestLookupDocumentation:
-    def test_known_object_type(self) -> None:
-        tool = get_tool_sync(mcp, "lookup_documentation")
-        result = tool.fn(object_type="Zone")
+    async def test_known_object_type(self, client: object) -> None:
+        result = await call_tool(client, "lookup_documentation", {"object_type": "Zone"}, LookupDocumentationResult)
         assert result.object_type == "Zone"
         assert result.io_reference_url is not None
         assert "docs.idfkit.com" in result.io_reference_url
@@ -28,41 +33,40 @@ class TestLookupDocumentation:
         assert result.search_url is not None
         assert result.version  # should be set
 
-    def test_unknown_object_type(self) -> None:
-        tool = get_tool_sync(mcp, "lookup_documentation")
-        result = tool.fn(object_type="NotARealType")
+    async def test_unknown_object_type(self, client: object) -> None:
+        result = await call_tool(
+            client, "lookup_documentation", {"object_type": "NotARealType"}, LookupDocumentationResult
+        )
         assert result.object_type == "NotARealType"
         assert result.io_reference_url is None
         assert result.engineering_reference_url is not None
         assert result.search_url is not None
 
-    def test_with_explicit_version(self) -> None:
-        tool = get_tool_sync(mcp, "lookup_documentation")
-        result = tool.fn(object_type="Zone", version="24.1.0")
+    async def test_with_explicit_version(self, client: object) -> None:
+        result = await call_tool(
+            client, "lookup_documentation", {"object_type": "Zone", "version": "24.1.0"}, LookupDocumentationResult
+        )
         assert result.version == "24.1.0"
         assert result.io_reference_url is not None
         assert "/v24.1/" in result.io_reference_url
 
 
 class TestDescribeObjectTypeDocUrl:
-    def test_doc_url_present(self) -> None:
-        tool = get_tool_sync(mcp, "describe_object_type")
-        result = tool.fn(object_type="Zone")
+    async def test_doc_url_present(self, client: object) -> None:
+        result = await call_tool(client, "describe_object_type", {"object_type": "Zone"}, DescribeObjectTypeResult)
         assert result.doc_url is not None
         assert "docs.idfkit.com" in result.doc_url
         assert "#zone" in result.doc_url
 
-    def test_doc_url_for_material(self) -> None:
-        tool = get_tool_sync(mcp, "describe_object_type")
-        result = tool.fn(object_type="Material")
+    async def test_doc_url_for_material(self, client: object) -> None:
+        result = await call_tool(client, "describe_object_type", {"object_type": "Material"}, DescribeObjectTypeResult)
         assert result.doc_url is not None
         assert "#material" in result.doc_url
 
 
 class TestSearchSchemaDocUrl:
-    def test_doc_url_in_matches(self) -> None:
-        tool = get_tool_sync(mcp, "search_schema")
-        result = tool.fn(query="Material", limit=10)
+    async def test_doc_url_in_matches(self, client: object) -> None:
+        result = await call_tool(client, "search_schema", {"query": "Material", "limit": 10}, SearchSchemaResult)
         assert result.count > 0
         # All matches should have doc_url populated
         match_with_url = [m for m in result.matches if m.doc_url is not None]
@@ -71,112 +75,96 @@ class TestSearchSchemaDocUrl:
 
 
 class TestSearchDocs:
-    def test_basic_search(self) -> None:
-        tool = get_tool_sync(mcp, "search_docs")
-        result = tool.fn(query="zone")
+    async def test_basic_search(self, client: object) -> None:
+        result = await call_tool(client, "search_docs", {"query": "zone"}, SearchDocsResult)
         assert result.count > 0
         assert result.version
         assert all(hit.score > 0 for hit in result.results)
 
-    def test_results_have_doc_url(self) -> None:
-        tool = get_tool_sync(mcp, "search_docs")
-        result = tool.fn(query="zone")
+    async def test_results_have_doc_url(self, client: object) -> None:
+        result = await call_tool(client, "search_docs", {"query": "zone"}, SearchDocsResult)
         assert result.count > 0
         for hit in result.results:
             assert "docs.idfkit.com" in hit.doc_url
             assert hit.doc_url.startswith("https://")
 
-    def test_tag_filter(self) -> None:
-        tool = get_tool_sync(mcp, "search_docs")
-        result = tool.fn(query="zone", tags="Input Output Reference")
+    async def test_tag_filter(self, client: object) -> None:
+        result = await call_tool(
+            client, "search_docs", {"query": "zone", "tags": "Input Output Reference"}, SearchDocsResult
+        )
         assert result.count > 0
         assert all("Input Output Reference" in hit.tags for hit in result.results)
 
-    def test_limit(self) -> None:
-        tool = get_tool_sync(mcp, "search_docs")
-        result = tool.fn(query="material", limit=3)
+    async def test_limit(self, client: object) -> None:
+        result = await call_tool(client, "search_docs", {"query": "material", "limit": 3}, SearchDocsResult)
         assert len(result.results) <= 3
 
-    def test_html_stripped(self) -> None:
-        tool = get_tool_sync(mcp, "search_docs")
-        result = tool.fn(query="zone")
+    async def test_html_stripped(self, client: object) -> None:
+        result = await call_tool(client, "search_docs", {"query": "zone"}, SearchDocsResult)
         assert result.count > 0
         for hit in result.results:
             assert "<p>" not in hit.text
             assert "<code>" not in hit.text
             assert "<ul>" not in hit.text
 
-    def test_empty_query(self) -> None:
-        tool = get_tool_sync(mcp, "search_docs")
-        result = tool.fn(query="")
+    async def test_empty_query(self, client: object) -> None:
+        result = await call_tool(client, "search_docs", {"query": ""}, SearchDocsResult)
         assert result.count == 0
         assert result.results == []
 
-    def test_text_truncated(self) -> None:
-        tool = get_tool_sync(mcp, "search_docs")
-        result = tool.fn(query="zone", limit=20)
+    async def test_text_truncated(self, client: object) -> None:
+        result = await call_tool(client, "search_docs", {"query": "zone", "limit": 20}, SearchDocsResult)
         for hit in result.results:
             # Truncated text should be at most 500 chars + "..."
             assert len(hit.text) <= 503
 
-    def test_index_cached(self) -> None:
-        tool = get_tool_sync(mcp, "search_docs")
-        tool.fn(query="zone")
+    async def test_index_cached(self, client: object) -> None:
+        await call_tool(client, "search_docs", {"query": "zone"}, SearchDocsResult)
         state = get_state()
         cached = state.docs_index
         assert cached is not None
-        tool.fn(query="material")
+        await call_tool(client, "search_docs", {"query": "material"}, SearchDocsResult)
         assert state.docs_index is cached
 
 
 class TestGetDocSection:
-    def test_known_location(self) -> None:
-        search_tool = get_tool_sync(mcp, "search_docs")
-        section_tool = get_tool_sync(mcp, "get_doc_section")
-
-        search_result = search_tool.fn(query="zone heat balance")
+    async def test_known_location(self, client: object) -> None:
+        search_result = await call_tool(client, "search_docs", {"query": "zone heat balance"}, SearchDocsResult)
         assert search_result.count > 0
 
         loc = search_result.results[0].location
-        result = section_tool.fn(location=loc)
+        result = await call_tool(client, "get_doc_section", {"location": loc}, GetDocSectionResult)
         assert result.title
         assert result.doc_url
         assert "docs.idfkit.com" in result.doc_url
         assert result.version
 
-    def test_unknown_location(self) -> None:
-        section_tool = get_tool_sync(mcp, "get_doc_section")
+    async def test_unknown_location(self, client: object) -> None:
         with pytest.raises(ToolError, match="not found"):
-            section_tool.fn(location="nonexistent/path/#nothing")
+            await call_tool(client, "get_doc_section", {"location": "nonexistent/path/#nothing"})
 
-    def test_full_text_not_truncated(self) -> None:
-        """get_doc_section should return full text, unlike search_docs which truncates."""
-        search_tool = get_tool_sync(mcp, "search_docs")
-        section_tool = get_tool_sync(mcp, "get_doc_section")
-
-        # Search for something likely to have long text
-        search_result = search_tool.fn(query="zone heat balance", limit=10)
+    async def test_full_text_not_truncated(self, client: object) -> None:
+        search_result = await call_tool(
+            client, "search_docs", {"query": "zone heat balance", "limit": 10}, SearchDocsResult
+        )
         assert search_result.count > 0
 
-        # Find a result whose text was truncated in search
         for hit in search_result.results:
             if hit.text.endswith("..."):
-                full = section_tool.fn(location=hit.location)
+                full = await call_tool(client, "get_doc_section", {"location": hit.location}, GetDocSectionResult)
                 assert len(full.text) > 500
                 assert not full.text.endswith("...")
                 return
 
-        # If no truncated results, just verify get_doc_section works
-        result = section_tool.fn(location=search_result.results[0].location)
+        result = await call_tool(
+            client, "get_doc_section", {"location": search_result.results[0].location}, GetDocSectionResult
+        )
         assert len(result.text) >= 0
 
-    def test_html_stripped(self) -> None:
-        search_tool = get_tool_sync(mcp, "search_docs")
-        section_tool = get_tool_sync(mcp, "get_doc_section")
-
-        search_result = search_tool.fn(query="zone")
+    async def test_html_stripped(self, client: object) -> None:
+        search_result = await call_tool(client, "search_docs", {"query": "zone"}, SearchDocsResult)
         loc = search_result.results[0].location
-        result = section_tool.fn(location=loc)
+        result = await call_tool(client, "get_doc_section", {"location": loc}, GetDocSectionResult)
         assert "<p>" not in result.text
         assert "<code>" not in result.text
 

--- a/tests/test_validation_tools.py
+++ b/tests/test_validation_tools.py
@@ -5,42 +5,35 @@ from __future__ import annotations
 import pytest
 from fastmcp.exceptions import ToolError
 
+from idfkit_mcp.models import CheckReferencesResult, ValidationResult
 from idfkit_mcp.state import ServerState
-from tests.tool_helpers import get_tool_sync
-
-
-def _tool(name: str):
-    from idfkit_mcp.server import mcp
-
-    return get_tool_sync(mcp, name)
+from tests.conftest import call_tool
 
 
 class TestValidateModel:
-    def test_valid_model(self, state_with_model: ServerState) -> None:
+    async def test_valid_model(self, client: object, state_with_model: ServerState) -> None:
         state_with_model.document.add("Zone", "TestZone")  # type: ignore[union-attr]
-        result = _tool("validate_model").fn()
+        result = await call_tool(client, "validate_model", model=ValidationResult)
         assert result.is_valid is True
 
-    def test_with_zones(self, state_with_zones: ServerState) -> None:
-        result = _tool("validate_model").fn()
+    async def test_with_zones(self, client: object, state_with_zones: ServerState) -> None:
+        result = await call_tool(client, "validate_model", model=ValidationResult)
         assert result.is_valid is not None
 
-    def test_filter_by_type(self, state_with_zones: ServerState) -> None:
-        result = _tool("validate_model").fn(object_types=["Zone"])
+    async def test_filter_by_type(self, client: object, state_with_zones: ServerState) -> None:
+        result = await call_tool(client, "validate_model", {"object_types": ["Zone"]}, ValidationResult)
         assert result.is_valid is not None
 
-    def test_without_model(self) -> None:
+    async def test_without_model(self, client: object) -> None:
         with pytest.raises(ToolError):
-            _tool("validate_model").fn()
+            await call_tool(client, "validate_model")
 
 
 class TestCheckReferences:
-    def test_no_dangling(self, state_with_zones: ServerState) -> None:
-        result = _tool("check_references").fn()
-        # The surface references "Office" zone which exists
-        # construction_name is empty so it shouldn't count as dangling
+    async def test_no_dangling(self, client: object, state_with_zones: ServerState) -> None:
+        result = await call_tool(client, "check_references", model=CheckReferencesResult)
         assert result.dangling_count is not None
 
-    def test_without_model(self) -> None:
+    async def test_without_model(self, client: object) -> None:
         with pytest.raises(ToolError):
-            _tool("check_references").fn()
+            await call_tool(client, "check_references")

--- a/tests/test_weather_tools.py
+++ b/tests/test_weather_tools.py
@@ -5,43 +5,42 @@ from __future__ import annotations
 import pytest
 from fastmcp.exceptions import ToolError
 
-from tests.tool_helpers import get_tool_sync
-
-
-def _tool(name: str):
-    from idfkit_mcp.server import mcp
-
-    return get_tool_sync(mcp, name)
+from idfkit_mcp.models import SearchWeatherStationsResult
+from tests.conftest import call_tool
 
 
 class TestSearchWeatherStations:
-    def test_station_index_cached(self) -> None:
+    async def test_station_index_cached(self, client: object) -> None:
         from idfkit_mcp.state import get_state
 
         state = get_state()
         assert state.station_index is None
-        _tool("search_weather_stations").fn(query="Chicago")
+        await call_tool(client, "search_weather_stations", {"query": "Chicago"}, SearchWeatherStationsResult)
         assert state.station_index is not None
         cached = state.station_index
-        _tool("search_weather_stations").fn(query="Boston")
+        await call_tool(client, "search_weather_stations", {"query": "Boston"}, SearchWeatherStationsResult)
         assert state.station_index is cached
 
-    def test_text_search(self) -> None:
-        result = _tool("search_weather_stations").fn(query="Chicago")
+    async def test_text_search(self, client: object) -> None:
+        result = await call_tool(client, "search_weather_stations", {"query": "Chicago"}, SearchWeatherStationsResult)
         assert result.search_type == "text"
         assert result.count > 0
 
-    def test_spatial_search(self) -> None:
-        result = _tool("search_weather_stations").fn(latitude=41.88, longitude=-87.63)
+    async def test_spatial_search(self, client: object) -> None:
+        result = await call_tool(
+            client, "search_weather_stations", {"latitude": 41.88, "longitude": -87.63}, SearchWeatherStationsResult
+        )
         assert result.search_type == "spatial"
         assert result.count > 0
 
-    def test_no_params(self) -> None:
+    async def test_no_params(self, client: object) -> None:
         with pytest.raises(ToolError):
-            _tool("search_weather_stations").fn()
+            await call_tool(client, "search_weather_stations")
 
-    def test_country_filter(self) -> None:
-        result = _tool("search_weather_stations").fn(query="Chicago", country="USA")
+    async def test_country_filter(self, client: object) -> None:
+        result = await call_tool(
+            client, "search_weather_stations", {"query": "Chicago", "country": "USA"}, SearchWeatherStationsResult
+        )
         assert result.count > 0
         for station in result.stations:
             assert station["country"].upper() == "USA"
@@ -68,14 +67,14 @@ class TestStationModelValidation:
 
 
 class TestDownloadWeatherFile:
-    def test_no_params(self) -> None:
+    async def test_no_params(self, client: object) -> None:
         with pytest.raises(ToolError):
-            _tool("download_weather_file").fn()
+            await call_tool(client, "download_weather_file")
 
-    def test_query_no_match(self) -> None:
+    async def test_query_no_match(self, client: object) -> None:
         with pytest.raises(ToolError):
-            _tool("download_weather_file").fn(query="zzz_nonexistent_place_xyz")
+            await call_tool(client, "download_weather_file", {"query": "zzz_nonexistent_place_xyz"})
 
-    def test_wmo_no_match(self) -> None:
+    async def test_wmo_no_match(self, client: object) -> None:
         with pytest.raises(ToolError):
-            _tool("download_weather_file").fn(wmo="0000000")
+            await call_tool(client, "download_weather_file", {"wmo": "0000000"})

--- a/tests/test_write_tools.py
+++ b/tests/test_write_tools.py
@@ -7,123 +7,137 @@ import tempfile
 import pytest
 from fastmcp.exceptions import ToolError
 
+from idfkit_mcp.models import BatchAddResult, NewModelResult, RemoveObjectResult, RenameObjectResult, SaveModelResult
 from idfkit_mcp.state import ServerState, get_state
-from tests.tool_helpers import get_tool_sync
-
-
-def _tool(name: str):
-    from idfkit_mcp.server import mcp
-
-    return get_tool_sync(mcp, name)
+from tests.conftest import call_tool
 
 
 class TestNewModel:
-    def test_create_default(self) -> None:
-        result = _tool("new_model").fn()
+    async def test_create_default(self, client: object) -> None:
+        result = await call_tool(client, "new_model", model=NewModelResult)
         assert result.status == "created"
         assert result.version
         state = get_state()
         assert state.document is not None
 
-    def test_create_specific_version(self) -> None:
-        result = _tool("new_model").fn(version="24.1.0")
+    async def test_create_specific_version(self, client: object) -> None:
+        result = await call_tool(client, "new_model", {"version": "24.1.0"}, NewModelResult)
         assert result.status == "created"
         assert "24.1.0" in result.version
 
 
 class TestAddObject:
-    def test_add_zone(self, state_with_model: ServerState) -> None:
-        result = _tool("add_object").fn(object_type="Zone", name="TestZone")
+    async def test_add_zone(self, client: object, state_with_model: ServerState) -> None:
+        result = await call_tool(client, "add_object", {"object_type": "Zone", "name": "TestZone"})
         assert result["name"] == "TestZone"
         assert result["object_type"] == "Zone"
 
-    def test_add_with_fields(self, state_with_model: ServerState) -> None:
-        result = _tool("add_object").fn(
-            object_type="Zone", name="TestZone", fields={"x_origin": 10.0, "y_origin": 20.0}
+    async def test_add_with_fields(self, client: object, state_with_model: ServerState) -> None:
+        result = await call_tool(
+            client,
+            "add_object",
+            {"object_type": "Zone", "name": "TestZone", "fields": {"x_origin": 10.0, "y_origin": 20.0}},
         )
         assert result["name"] == "TestZone"
 
-    def test_add_unknown_type(self, state_with_model: ServerState) -> None:
+    async def test_add_unknown_type(self, client: object, state_with_model: ServerState) -> None:
         with pytest.raises(ToolError):
-            _tool("add_object").fn(object_type="NonExistent", name="Test")
+            await call_tool(client, "add_object", {"object_type": "NonExistent", "name": "Test"})
 
-    def test_add_without_model(self) -> None:
+    async def test_add_without_model(self, client: object) -> None:
         with pytest.raises(ToolError):
-            _tool("add_object").fn(object_type="Zone", name="Test")
+            await call_tool(client, "add_object", {"object_type": "Zone", "name": "Test"})
 
 
 class TestBatchAddObjects:
-    def test_batch_add(self, state_with_model: ServerState) -> None:
+    async def test_batch_add(self, client: object, state_with_model: ServerState) -> None:
         objects = [
             {"object_type": "Zone", "name": "Zone1"},
             {"object_type": "Zone", "name": "Zone2"},
             {"object_type": "Zone", "name": "Zone3"},
         ]
-        result = _tool("batch_add_objects").fn(objects=objects)
+        result = await call_tool(client, "batch_add_objects", {"objects": objects}, BatchAddResult)
         assert result.total == 3
         assert result.success == 3
         assert result.errors == 0
 
-    def test_batch_partial_failure(self, state_with_model: ServerState) -> None:
+    async def test_batch_partial_failure(self, client: object, state_with_model: ServerState) -> None:
         objects = [
             {"object_type": "Zone", "name": "Zone1"},
             {"object_type": "Zone", "name": "Zone1"},  # Duplicate
         ]
-        result = _tool("batch_add_objects").fn(objects=objects)
+        result = await call_tool(client, "batch_add_objects", {"objects": objects}, BatchAddResult)
         assert result.total == 2
         assert result.success == 1
         assert result.errors == 1
 
-    def test_batch_missing_type(self, state_with_model: ServerState) -> None:
+    async def test_batch_missing_type(self, client: object, state_with_model: ServerState) -> None:
         objects = [{"name": "Test"}]
-        result = _tool("batch_add_objects").fn(objects=objects)
+        result = await call_tool(client, "batch_add_objects", {"objects": objects}, BatchAddResult)
         assert result.errors == 1
 
 
 class TestUpdateObject:
-    def test_update_fields(self, state_with_model: ServerState) -> None:
-        _tool("add_object").fn(object_type="Zone", name="TestZone")
-        result = _tool("update_object").fn(object_type="Zone", name="TestZone", fields={"x_origin": 5.0})
+    async def test_update_fields(self, client: object, state_with_model: ServerState) -> None:
+        await call_tool(client, "add_object", {"object_type": "Zone", "name": "TestZone"})
+        result = await call_tool(
+            client, "update_object", {"object_type": "Zone", "name": "TestZone", "fields": {"x_origin": 5.0}}
+        )
         assert "x_origin" in result
 
-    def test_update_nonexistent(self, state_with_model: ServerState) -> None:
+    async def test_update_nonexistent(self, client: object, state_with_model: ServerState) -> None:
         with pytest.raises(ToolError):
-            _tool("update_object").fn(object_type="Zone", name="Missing", fields={"x_origin": 5.0})
+            await call_tool(
+                client, "update_object", {"object_type": "Zone", "name": "Missing", "fields": {"x_origin": 5.0}}
+            )
 
 
 class TestRemoveObject:
-    def test_remove_unreferenced(self, state_with_zones: ServerState) -> None:
-        result = _tool("remove_object").fn(object_type="Zone", name="Corridor")
+    async def test_remove_unreferenced(self, client: object, state_with_zones: ServerState) -> None:
+        result = await call_tool(
+            client, "remove_object", {"object_type": "Zone", "name": "Corridor"}, RemoveObjectResult
+        )
         assert result.status == "removed"
 
-    def test_remove_referenced_blocked(self, state_with_zones: ServerState) -> None:
+    async def test_remove_referenced_blocked(self, client: object, state_with_zones: ServerState) -> None:
         with pytest.raises(ToolError, match="referenced"):
-            _tool("remove_object").fn(object_type="Zone", name="Office")
+            await call_tool(client, "remove_object", {"object_type": "Zone", "name": "Office"})
 
-    def test_remove_referenced_forced(self, state_with_zones: ServerState) -> None:
-        result = _tool("remove_object").fn(object_type="Zone", name="Office", force=True)
+    async def test_remove_referenced_forced(self, client: object, state_with_zones: ServerState) -> None:
+        result = await call_tool(
+            client, "remove_object", {"object_type": "Zone", "name": "Office", "force": True}, RemoveObjectResult
+        )
         assert result.status == "removed"
 
 
 class TestRenameObject:
-    def test_rename(self, state_with_zones: ServerState) -> None:
-        result = _tool("rename_object").fn(object_type="Zone", old_name="Office", new_name="MainOffice")
+    async def test_rename(self, client: object, state_with_zones: ServerState) -> None:
+        result = await call_tool(
+            client,
+            "rename_object",
+            {"object_type": "Zone", "old_name": "Office", "new_name": "MainOffice"},
+            RenameObjectResult,
+        )
         assert result.status == "renamed"
         assert result.references_updated >= 1
 
 
 class TestDuplicateObject:
-    def test_duplicate(self, state_with_zones: ServerState) -> None:
-        result = _tool("duplicate_object").fn(object_type="Zone", name="Office", new_name="OfficeClone")
+    async def test_duplicate(self, client: object, state_with_zones: ServerState) -> None:
+        result = await call_tool(
+            client, "duplicate_object", {"object_type": "Zone", "name": "Office", "new_name": "OfficeClone"}
+        )
         assert result["name"] == "OfficeClone"
 
 
 class TestUpdateObjectSingleton:
     """Singleton types should be updatable."""
 
-    def test_update_singleton(self, state_with_singletons: ServerState) -> None:
-        result = _tool("update_object").fn(
-            object_type="SimulationControl", name="", fields={"do_zone_sizing_calculation": "No"}
+    async def test_update_singleton(self, client: object, state_with_singletons: ServerState) -> None:
+        result = await call_tool(
+            client,
+            "update_object",
+            {"object_type": "SimulationControl", "name": "", "fields": {"do_zone_sizing_calculation": "No"}},
         )
         assert result["object_type"] == "SimulationControl"
 
@@ -131,24 +145,31 @@ class TestUpdateObjectSingleton:
 class TestRemoveObjectSingleton:
     """Singleton types should be removable."""
 
-    def test_remove_singleton(self, state_with_singletons: ServerState) -> None:
-        result = _tool("remove_object").fn(object_type="GlobalGeometryRules", name="", force=True)
+    async def test_remove_singleton(self, client: object, state_with_singletons: ServerState) -> None:
+        result = await call_tool(
+            client,
+            "remove_object",
+            {"object_type": "GlobalGeometryRules", "name": "", "force": True},
+            RemoveObjectResult,
+        )
         assert result.status == "removed"
 
 
 class TestSaveModel:
-    def test_save_idf(self, state_with_zones: ServerState) -> None:
+    async def test_save_idf(self, client: object, state_with_zones: ServerState) -> None:
         with tempfile.NamedTemporaryFile(suffix=".idf", delete=False) as f:
-            result = _tool("save_model").fn(file_path=f.name)
+            result = await call_tool(client, "save_model", {"file_path": f.name}, SaveModelResult)
         assert result.status == "saved"
         assert result.format == "idf"
 
-    def test_save_epjson(self, state_with_zones: ServerState) -> None:
+    async def test_save_epjson(self, client: object, state_with_zones: ServerState) -> None:
         with tempfile.NamedTemporaryFile(suffix=".epjson", delete=False) as f:
-            result = _tool("save_model").fn(file_path=f.name, output_format="epjson")
+            result = await call_tool(
+                client, "save_model", {"file_path": f.name, "output_format": "epjson"}, SaveModelResult
+            )
         assert result.status == "saved"
         assert result.format == "epjson"
 
-    def test_save_no_path(self, state_with_model: ServerState) -> None:
+    async def test_save_no_path(self, client: object, state_with_model: ServerState) -> None:
         with pytest.raises(ToolError):
-            _tool("save_model").fn()
+            await call_tool(client, "save_model")

--- a/tests/tool_helpers.py
+++ b/tests/tool_helpers.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import inspect
 import typing
 from dataclasses import dataclass
 from typing import Any
@@ -68,6 +69,34 @@ def list_tools_sync(server: Any) -> dict[str, Any]:
     """Fetch all registered tools from a server in synchronous tests."""
     tools = asyncio.run(server._local_provider.list_tools())
     return {tool.name: tool for tool in tools}
+
+
+def list_resources_sync(server: Any) -> dict[str, Any]:
+    """Fetch all registered resources from a server in synchronous tests."""
+    resources = asyncio.run(server._local_provider.list_resources())
+    return {str(resource.uri): resource for resource in resources}
+
+
+def list_resource_templates_sync(server: Any) -> dict[str, Any]:
+    """Fetch all registered resource templates from a server in synchronous tests."""
+    templates = asyncio.run(server._local_provider.list_resource_templates())
+    return {str(template.uri_template): template for template in templates}
+
+
+def read_resource_sync(server: Any, uri: str) -> Any:
+    """Resolve and read a resource by URI in synchronous tests."""
+    resource = asyncio.run(server._local_provider.get_resource(uri))
+    if resource is None:
+        templates = asyncio.run(server._local_provider.list_resource_templates())
+        for template in templates:
+            params = template.matches(uri)
+            if params is not None:
+                created_resource = template.create_resource(uri, params)
+                resource = asyncio.run(created_resource) if inspect.isawaitable(created_resource) else created_resource
+                break
+    if resource is None:
+        raise KeyError(uri)
+    return asyncio.run(resource.read())
 
 
 async def get_tool_async(server: Any, name: str) -> Any:


### PR DESCRIPTION
## Summary
- Replace `_tool("name").fn()` pattern with `await call_tool(client, ...)` that exercises tools through the full MCP protocol via FastMCP Client
- All tests are now async, using a shared `client` fixture with in-memory transport
- Add `call_tool` / `read_resource_json` helpers for typed result decoding
- Add resource read tests (model summary, schema template, object template)

## Test plan
- [x] `make check` passes
- [x] `make test` passes (141 tests — 4 new resource tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)