### PR TITLE
Fix documentation drift from recent code changes

### DIFF
--- a/docs/api/app.md
+++ b/docs/api/app.md
@@ -1,0 +1,1 @@
+::: idfkit_mcp.app

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -4,8 +4,10 @@ This section is generated from source docstrings.
 
 ## Modules
 
+- [App](app.md)
 - [Server](server.md)
 - [State](state.md)
+- [Resources](resources.md)
 - [Tools: Schema](tools-schema.md)
 - [Tools: Read](tools-read.md)
 - [Tools: Write](tools-write.md)

--- a/docs/api/resources.md
+++ b/docs/api/resources.md
@@ -1,0 +1,1 @@
+::: idfkit_mcp.resources

--- a/docs/concepts/server-state.md
+++ b/docs/concepts/server-state.md
@@ -49,6 +49,19 @@ Behavior:
 - Session file is keyed by working directory (SHA-256 hash) and stored in `~/.cache/idfkit/sessions/` (Linux) or `~/Library/Caches/idfkit/sessions/` (macOS).
 - Use `clear_session` to delete the session file and reset all state.
 
+## MCP Resources
+
+In addition to tools, the server exposes read-only MCP resources that let clients subscribe to model state without making tool calls.
+
+| URI | Description |
+|-----|-------------|
+| `idfkit://model/summary` | Current model summary (version, zones, object counts) |
+| `idfkit://schema/{object_type}` | Full field schema for an object type |
+| `idfkit://model/objects/{object_type}/{name}` | All field values for a specific object |
+| `idfkit://simulation/results` | Summary of the most recent simulation results |
+
+Resources return JSON (`application/json`) and are available whenever the corresponding state exists (e.g., `model/summary` requires a loaded model).
+
 ## Session Strategy
 
 For deterministic automation:

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -103,6 +103,8 @@ idfkit-mcp --transport stdio
 idfkit-mcp --transport streamable-http --host 127.0.0.1 --port 8000
 ```
 
+`--transport http` is also accepted as a shorter alias.
+
 ### Environment Variable Configuration
 
 ```bash

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,7 +32,7 @@ model editing, validation, weather acquisition, and simulation via idfkit.
 
 <div class="feature-chips" markdown>
 
-<span class="chip">:material-tools: 25 MCP tools</span>
+<span class="chip">:material-tools: 32 MCP tools</span>
 <span class="chip">:material-shape-outline: Schema-aware edits</span>
 <span class="chip">:material-shield-check-outline: Validation + references</span>
 <span class="chip">:material-weather-cloudy: Weather search + download</span>

--- a/docs/tools/docs.md
+++ b/docs/tools/docs.md
@@ -21,7 +21,7 @@ Parameters:
 
 Full-text search across the EnergyPlus documentation index (~20,000 sections).
 
-Results include HTML-stripped text truncated to 500 characters. Use `get_doc_section` to read full content.
+Results include HTML-stripped text truncated to 250 characters. Use `get_doc_section` to read full content.
 
 Parameters:
 
@@ -49,8 +49,9 @@ Parameters:
 
 - `location` (required): the location from a `search_docs` result
 - `version`: EnergyPlus version as `"X.Y"` (default: latest)
+- `max_length`: maximum characters to return (default: 8000)
 
-Returns the full text (not truncated) with HTML stripped.
+Returns the text with HTML stripped, truncated to `max_length` characters.
 
 ## Typical Flows
 

--- a/docs/tools/simulation.md
+++ b/docs/tools/simulation.md
@@ -11,6 +11,7 @@ Parameters:
 - `annual`: annual run
 - `energyplus_dir`: optional explicit EnergyPlus directory or executable path
 - `energyplus_version`: optional EnergyPlus version filter (for example `25.1.0`)
+- `output_directory`: optional output directory for simulation results
 
 Behavior:
 

--- a/docs/tools/validation.md
+++ b/docs/tools/validation.md
@@ -24,6 +24,7 @@ Performs explicit dangling-reference detection.
 Response:
 
 - `dangling_count`
+- `returned` (number of items in the response, may be less than total)
 - list of source object, field, and missing target
 
 ## Recommended Gate

--- a/docs/tools/weather.md
+++ b/docs/tools/weather.md
@@ -12,7 +12,8 @@ Two query modes:
 Optional filters:
 
 - `country` (e.g., `USA`)
-- `limit`
+- `state` (e.g., `"MA"`, `"IL"`)
+- `limit` (default `5`)
 
 Returns station metadata, plus:
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -40,8 +40,10 @@ nav:
 
   - API Reference:
     - Overview: api/index.md
+    - App: api/app.md
     - Server: api/server.md
     - State: api/state.md
+    - Resources: api/resources.md
     - Tools:
       - Schema: api/tools-schema.md
       - Read: api/tools-read.md


### PR DESCRIPTION
## Summary
- Fix tool count on homepage: 25 → 32
- Fix `search_docs` truncation length: 500 → 250 chars
- Add missing parameters: `state` (weather), `output_directory` (simulation), `max_length` (get_doc_section)
- Fix incorrect "not truncated" claim for `get_doc_section`
- Document new MCP resources (model summary, schema, objects, simulation results)
- Add `returned` field to `check_references` response docs
- Document `http` transport alias
- Add API reference pages for `app` and `resources` modules

## Test plan
- [x] `make check` passes
- [x] `make test` passes (141 tests)
- [x] mkdocs nav YAML is valid
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)