### PR TITLE
Fix resource template MIME type defaulting to text/plain

### DIFF
--- a/src/idfkit_mcp/resources.py
+++ b/src/idfkit_mcp/resources.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 from typing import Any
 
+from fastmcp.resources.resource import ResourceContent, ResourceResult
 from pydantic import BaseModel
 
 from idfkit_mcp.app import mcp
@@ -16,12 +17,21 @@ from idfkit_mcp.tools.read import build_model_summary, build_references
 from idfkit_mcp.tools.schema import describe_object_type
 from idfkit_mcp.tools.simulation import get_results_summary
 
+JSON_MIME = "application/json"
 
-def _to_resource_json(value: BaseModel | dict[str, Any]) -> str:
-    """Serialize resource payloads as formatted JSON."""
+
+def _to_resource_json(value: BaseModel | dict[str, Any]) -> ResourceResult:
+    """Serialize resource payloads as JSON with correct MIME type.
+
+    Returns a ResourceResult directly to work around a FastMCP bug where
+    ResourceTemplate.convert_result() drops the registered mime_type for
+    template resources (URIs with parameters), defaulting to text/plain.
+    """
     if isinstance(value, BaseModel):
-        return value.model_dump_json(indent=2)
-    return json.dumps(value, indent=2, sort_keys=True, default=str)
+        text = value.model_dump_json(indent=2)
+    else:
+        text = json.dumps(value, indent=2, sort_keys=True, default=str)
+    return ResourceResult([ResourceContent(text, mime_type=JSON_MIME)])
 
 
 @mcp.resource(
@@ -31,7 +41,7 @@ def _to_resource_json(value: BaseModel | dict[str, Any]) -> str:
     description="Version, zones, object counts, and groups for the loaded model.",
     mime_type="application/json",
 )
-def model_summary() -> str:
+def model_summary() -> ResourceResult:
     """Current model summary as JSON."""
     state = get_state()
     doc = state.require_model()
@@ -45,7 +55,7 @@ def model_summary() -> str:
     description="Full field schema for an EnergyPlus object type.",
     mime_type="application/json",
 )
-def object_schema(object_type: str) -> str:
+def object_schema(object_type: str) -> ResourceResult:
     """Full schema description for an EnergyPlus object type as JSON."""
     return _to_resource_json(describe_object_type(object_type))
 
@@ -57,7 +67,7 @@ def object_schema(object_type: str) -> str:
     description="All field values for a specific EnergyPlus object.",
     mime_type="application/json",
 )
-def object_data(object_type: str, name: str) -> str:
+def object_data(object_type: str, name: str) -> ResourceResult:
     """Serialized model object data as JSON."""
     state = get_state()
     doc = state.require_model()
@@ -72,7 +82,7 @@ def object_data(object_type: str, name: str) -> str:
     description="Energy metrics, errors, and tables from the last simulation.",
     mime_type="application/json",
 )
-def simulation_results() -> str:
+def simulation_results() -> ResourceResult:
     """Latest simulation results summary as JSON."""
     return _to_resource_json(get_results_summary())
 
@@ -84,7 +94,7 @@ def simulation_results() -> str:
     description="I/O Reference, Engineering Reference, and search URLs for an object type.",
     mime_type="application/json",
 )
-def documentation_urls(object_type: str) -> str:
+def documentation_urls(object_type: str) -> ResourceResult:
     """Documentation URLs for an EnergyPlus object type as JSON."""
     return _to_resource_json(build_documentation_urls(object_type))
 
@@ -96,7 +106,7 @@ def documentation_urls(object_type: str) -> str:
     description="Bidirectional references: who references this object and what it references.",
     mime_type="application/json",
 )
-def object_references(name: str) -> str:
+def object_references(name: str) -> ResourceResult:
     """Bidirectional reference graph for an object as JSON."""
     state = get_state()
     doc = state.require_model()


### PR DESCRIPTION
## Summary
- Work around a FastMCP bug where `ResourceTemplate.convert_result()` drops the registered `mime_type` for template resources (URIs with `{param}` placeholders), causing responses to default to `text/plain` instead of `application/json`
- Return `ResourceResult` directly from `_to_resource_json()` with explicit MIME type, bypassing the buggy code path
- Affects 4 template resources (`schema`, `object_data`, `documentation_urls`, `object_references`); the 2 static resources (`model_summary`, `simulation_results`) were already correct but are updated for consistency

## Root cause
`ResourceTemplate.convert_result()` wraps plain string returns in `ResourceResult(raw_value)` without passing the template's `mime_type`, so `ResourceContent` defaults to `text/plain`. The equivalent `Resource.convert_result()` correctly passes `mime_type=self.mime_type`. This is an upstream FastMCP bug.

## Test plan
- [x] `make check` passes (ruff, pyright, deptry)
- [x] `make test` passes (138 tests)
- [x] Verified `mcp.read_resource('idfkit://docs/RunPeriod')` returns `mimeType: application/json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)