### PR TITLE
Allow null meter key_value in timeseries results

### DIFF
--- a/src/idfkit_mcp/models.py
+++ b/src/idfkit_mcp/models.py
@@ -420,7 +420,7 @@ class QueryTimeseriesResult(BaseModel):
     """Response from ``query_timeseries``."""
 
     variable_name: str
-    key_value: str
+    key_value: str | None = None
     units: str
     frequency: str
     total_points: int
@@ -433,7 +433,7 @@ class ExportTimeseriesResult(BaseModel):
 
     path: str
     variable_name: str
-    key_value: str
+    key_value: str | None = None
     units: str
     frequency: str
     rows: int

--- a/tests/test_simulation_tools.py
+++ b/tests/test_simulation_tools.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from datetime import datetime
+from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -64,8 +67,71 @@ class TestQueryTimeseries:
         with pytest.raises(ToolError):
             await call_tool(client, "query_timeseries", {"variable_name": "Zone Mean Air Temperature"})
 
+    async def test_meter_with_null_key_value(
+        self, client: object, state_with_sql_only_simulation: ServerState, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        fake_ts = SimpleNamespace(
+            variable_name="DistrictCooling:Facility",
+            key_value=None,
+            units="J",
+            frequency="Hourly",
+            timestamps=[datetime(2013, 1, 1, 1, 0, 0)],
+            values=[123.0],
+        )
+        monkeypatch.setattr("idfkit.simulation.parsers.sql.SQLResult.get_timeseries", lambda *_args, **_kwargs: fake_ts)
+
+        result = await call_tool(
+            client,
+            "query_timeseries",
+            {
+                "variable_name": "DistrictCooling:Facility",
+                "key_value": "*",
+                "frequency": "Hourly",
+                "environment": "annual",
+            },
+        )
+
+        assert result["variable_name"] == "DistrictCooling:Facility"
+        assert result["key_value"] is None
+        assert result["returned"] == 1
+
 
 class TestExportTimeseries:
     async def test_no_simulation(self, client: object) -> None:
         with pytest.raises(ToolError):
             await call_tool(client, "export_timeseries", {"variable_name": "Zone Mean Air Temperature"})
+
+    async def test_meter_with_null_key_value(
+        self,
+        client: object,
+        state_with_sql_only_simulation: ServerState,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+    ) -> None:
+        fake_ts = SimpleNamespace(
+            variable_name="DistrictCooling:Facility",
+            key_value=None,
+            units="J",
+            frequency="Hourly",
+            timestamps=[datetime(2013, 1, 1, 1, 0, 0)],
+            values=[456.0],
+        )
+        monkeypatch.setattr("idfkit.simulation.parsers.sql.SQLResult.get_timeseries", lambda *_args, **_kwargs: fake_ts)
+
+        output_path = tmp_path / "district_cooling.csv"
+        result = await call_tool(
+            client,
+            "export_timeseries",
+            {
+                "variable_name": "DistrictCooling:Facility",
+                "key_value": "*",
+                "frequency": "Hourly",
+                "environment": "annual",
+                "output_path": str(output_path),
+            },
+        )
+
+        assert result["variable_name"] == "DistrictCooling:Facility"
+        assert result["key_value"] is None
+        assert result["rows"] == 1
+        assert output_path.exists()


### PR DESCRIPTION
## Summary
- allow query_timeseries and export_timeseries responses to return key_value: null
- keep facility meter payloads valid when SQL returns an empty/null key
- add regression tests for null-key meter query/export responses

## Testing
- python -m pytest tests/test_simulation_tools.py -q