### PR TITLE
feat: add get_zone_properties tool and bump idfkit to >=0.6.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 keywords = ["energyplus", "mcp", "idfkit", "building-energy"]
 requires-python = ">=3.10,<4.0"
 dependencies = [
-    "idfkit>=0.6.3",
+    "idfkit>=0.6.4",
     "fastmcp>=3.1.0",
     "mcp>=1.2.0",
     "openstudio==3.11.0",

--- a/src/idfkit_mcp/models.py
+++ b/src/idfkit_mcp/models.py
@@ -487,6 +487,44 @@ class ClearSessionResult(BaseModel):
 
 
 # ---------------------------------------------------------------------------
+# Zone properties tool responses
+# ---------------------------------------------------------------------------
+
+
+class SurfaceTypeCounts(BaseModel):
+    """Surface counts by type for a zone."""
+
+    walls: int = 0
+    floors: int = 0
+    ceilings: int = 0
+    roofs: int = 0
+    windows: int = 0
+    doors: int = 0
+    other: int = 0
+
+
+class ZoneProperties(BaseModel):
+    """Typed summary for one EnergyPlus zone."""
+
+    name: str
+    floor_area_m2: float | None = None
+    volume_m3: float | None = None
+    height_m: float | None = None
+    surface_counts: SurfaceTypeCounts
+    constructions: list[str]
+    schedules: list[str]
+    hvac_connections: list[str]
+    thermostats: list[str]
+
+
+class GetZonePropertiesResult(BaseModel):
+    """Response from ``get_zone_properties``."""
+
+    zone_count: int
+    zones: list[ZoneProperties]
+
+
+# ---------------------------------------------------------------------------
 # Model integrity tool responses
 # ---------------------------------------------------------------------------
 

--- a/src/idfkit_mcp/server.py
+++ b/src/idfkit_mcp/server.py
@@ -19,8 +19,22 @@ from idfkit_mcp.tools import simulation as _simulation
 from idfkit_mcp.tools import validation as _validation
 from idfkit_mcp.tools import weather as _weather
 from idfkit_mcp.tools import write as _write
+from idfkit_mcp.tools import zone_properties as _zone_properties
 
-_ = (_resources, _docs, _geometry, _integrity, _read, _schedule, _schema, _simulation, _validation, _weather, _write)
+_ = (
+    _resources,
+    _docs,
+    _geometry,
+    _integrity,
+    _read,
+    _schedule,
+    _schema,
+    _simulation,
+    _validation,
+    _weather,
+    _write,
+    _zone_properties,
+)
 
 Transport = Literal["stdio", "sse", "http"]
 _TRANSPORT_CHOICES = ("stdio", "sse", "http", "streamable-http")

--- a/src/idfkit_mcp/tools/zone_properties.py
+++ b/src/idfkit_mcp/tools/zone_properties.py
@@ -1,0 +1,192 @@
+"""Zone properties tool — typed summary of zone geometry, surfaces, constructions, and HVAC."""
+
+from __future__ import annotations
+
+import logging
+from typing import Annotated, Any
+
+from mcp.types import ToolAnnotations
+from pydantic import Field
+
+from idfkit_mcp.app import mcp
+from idfkit_mcp.models import GetZonePropertiesResult, SurfaceTypeCounts, ZoneProperties
+from idfkit_mcp.state import get_state
+
+logger = logging.getLogger(__name__)
+
+_READ_ONLY = ToolAnnotations(readOnlyHint=True, destructiveHint=False, idempotentHint=True, openWorldHint=False)
+
+_SURFACE_TYPE_MAP: dict[str, str] = {
+    "wall": "walls",
+    "floor": "floors",
+    "ceiling": "ceilings",
+    "roof": "roofs",
+}
+
+
+def _zone_geometry(doc: Any, zone_name: str, has_surfaces: bool) -> tuple[float | None, float | None, float | None]:
+    """Return (floor_area_m2, volume_m3, height_m) or (None, None, None) if no surfaces."""
+    if not has_surfaces:
+        return None, None, None
+    try:
+        from idfkit.geometry import calculate_zone_floor_area, calculate_zone_height, calculate_zone_volume
+
+        area = calculate_zone_floor_area(doc, zone_name)
+        vol = calculate_zone_volume(doc, zone_name)
+        height = calculate_zone_height(doc, zone_name)
+        return (
+            round(area, 3) if area > 0 else None,
+            round(vol, 3) if vol > 0 else None,
+            round(height, 3) if height > 0 else None,
+        )
+    except Exception:
+        logger.debug("Could not compute geometry for zone '%s'", zone_name, exc_info=True)
+        return None, None, None
+
+
+def _surface_counts(doc: Any, zone_name: str) -> tuple[SurfaceTypeCounts, set[str]]:
+    """Count surfaces by type for a zone; return counts and set of host surface names."""
+    counts = SurfaceTypeCounts()
+    host_surfaces: set[str] = set()
+
+    if "BuildingSurface:Detailed" not in doc:
+        return counts, host_surfaces
+
+    for surface in doc.get_collection("BuildingSurface:Detailed"):
+        if surface.data.get("zone_name", "").lower() != zone_name.lower():
+            continue
+        host_surfaces.add(surface.name.lower())
+        surface_type = surface.data.get("surface_type", "").lower()
+        bucket = _SURFACE_TYPE_MAP.get(surface_type, "other")
+        setattr(counts, bucket, getattr(counts, bucket) + 1)
+
+    return counts, host_surfaces
+
+
+def _fenestration_counts(doc: Any, host_surfaces: set[str]) -> tuple[int, int]:
+    """Count windows and doors for surfaces in this zone."""
+    windows = doors = 0
+    if "FenestrationSurface:Detailed" not in doc:
+        return windows, doors
+    for fen in doc.get_collection("FenestrationSurface:Detailed"):
+        if fen.data.get("building_surface_name", "").lower() not in host_surfaces:
+            continue
+        if fen.data.get("surface_type", "").lower() == "door":
+            doors += 1
+        else:
+            windows += 1
+    return windows, doors
+
+
+def _zone_constructions(doc: Any, zone_name: str) -> list[str]:
+    """Unique construction names used by surfaces in this zone."""
+    names: set[str] = set()
+    if "BuildingSurface:Detailed" in doc:
+        for surface in doc.get_collection("BuildingSurface:Detailed"):
+            if surface.data.get("zone_name", "").lower() != zone_name.lower():
+                continue
+            cn = surface.data.get("construction_name", "")
+            if cn:
+                names.add(cn)
+    return sorted(names)
+
+
+def _zone_schedules(doc: Any, zone_name: str) -> list[str]:
+    """Schedule names referenced by objects that themselves reference this zone."""
+    schedules: set[str] = set()
+    for obj in doc.get_referencing(zone_name):
+        for field, value in obj.data.items():
+            if "schedule" in field and isinstance(value, str) and value:
+                schedules.add(value)
+    return sorted(schedules)
+
+
+def _zone_hvac_connections(doc: Any, zone_name: str) -> list[str]:
+    """ZoneHVAC:EquipmentConnections names for this zone.
+
+    Falls back to the zone_name field when the connection object itself is unnamed
+    (which is valid in EnergyPlus — ZoneHVAC:EquipmentConnections may use the zone
+    name as its implicit identifier).
+    """
+    if "ZoneHVAC:EquipmentConnections" not in doc:
+        return []
+    results: list[str] = []
+    for conn in doc.get_collection("ZoneHVAC:EquipmentConnections"):
+        if conn.data.get("zone_name", "").lower() != zone_name.lower():
+            continue
+        # Use explicit name if present; fall back to zone_name (the implicit key)
+        results.append(conn.name or conn.data.get("zone_name", zone_name))
+    return results
+
+
+def _zone_thermostats(doc: Any, zone_name: str) -> list[str]:
+    """Control object names from ZoneControl:Thermostat for this zone."""
+    if "ZoneControl:Thermostat" not in doc:
+        return []
+    thermostats: list[str] = []
+    for ctrl in doc.get_collection("ZoneControl:Thermostat"):
+        zl = ctrl.data.get("zone_or_zonelist_or_space_or_spacelist_name", "")
+        if not zl:
+            zl = ctrl.data.get("zone_or_zonelist_name", "")
+        if zl.lower() == zone_name.lower():
+            control_name = ctrl.data.get("control_object_name", "")
+            if control_name:
+                thermostats.append(control_name)
+    return thermostats
+
+
+def _build_zone_properties(doc: Any, zone_name: str) -> ZoneProperties:
+    """Build a ZoneProperties summary for one zone."""
+    counts, host_surfaces = _surface_counts(doc, zone_name)
+    has_surfaces = len(host_surfaces) > 0
+    windows, doors = _fenestration_counts(doc, host_surfaces)
+    counts.windows = windows
+    counts.doors = doors
+
+    area, vol, height = _zone_geometry(doc, zone_name, has_surfaces)
+
+    return ZoneProperties(
+        name=zone_name,
+        floor_area_m2=area,
+        volume_m3=vol,
+        height_m=height,
+        surface_counts=counts,
+        constructions=_zone_constructions(doc, zone_name),
+        schedules=_zone_schedules(doc, zone_name),
+        hvac_connections=_zone_hvac_connections(doc, zone_name),
+        thermostats=_zone_thermostats(doc, zone_name),
+    )
+
+
+@mcp.tool(annotations=_READ_ONLY)
+def get_zone_properties(
+    zone_name: Annotated[str | None, Field(description="Zone name. Omit for all zones.")] = None,
+) -> GetZonePropertiesResult:
+    """Typed summary of zone geometry, surfaces, constructions, schedules, and HVAC.
+
+    Returns floor area, volume, ceiling height, surface counts by type (walls/floors/roofs/
+    windows/doors), unique construction names, schedule names referenced by zone loads,
+    HVAC equipment connection names, and thermostat control object names.
+
+    Geometry values (area, volume, height) are calculated from BuildingSurface:Detailed
+    vertices and returned as None when no surfaces exist for the zone.
+
+    Preconditions: model loaded.
+    Side effects: none — read-only.
+    """
+    state = get_state()
+    doc = state.require_model()
+
+    if zone_name is not None:
+        if "Zone" not in doc or doc.get_collection("Zone").get(zone_name) is None:
+            from fastmcp.exceptions import ToolError
+
+            raise ToolError(f"Zone '{zone_name}' not found in the model.")
+        zones = [_build_zone_properties(doc, zone_name)]
+    else:
+        if "Zone" not in doc:
+            return GetZonePropertiesResult(zone_count=0, zones=[])
+        zones = [_build_zone_properties(doc, z.name) for z in doc.get_collection("Zone")]
+
+    logger.debug("get_zone_properties: returned %d zone(s)", len(zones))
+    return GetZonePropertiesResult(zone_count=len(zones), zones=zones)

--- a/tests/test_zone_properties_tool.py
+++ b/tests/test_zone_properties_tool.py
@@ -1,0 +1,137 @@
+"""Tests for the get_zone_properties tool."""
+
+from __future__ import annotations
+
+import pytest
+from fastmcp.exceptions import ToolError
+from idfkit import new_document
+
+from idfkit_mcp.models import GetZonePropertiesResult
+from idfkit_mcp.state import ServerState, get_state
+from tests.conftest import call_tool
+
+
+class TestGetZoneProperties:
+    async def test_no_model_raises(self, client: object) -> None:
+        with pytest.raises(ToolError):
+            await call_tool(client, "get_zone_properties")
+
+    async def test_empty_model_no_zones(self, client: object, state_with_model: ServerState) -> None:
+        result = await call_tool(client, "get_zone_properties", model=GetZonePropertiesResult)
+        assert result.zone_count == 0
+        assert result.zones == []
+
+    async def test_all_zones(self, client: object, state_with_zones: ServerState) -> None:
+        result = await call_tool(client, "get_zone_properties", model=GetZonePropertiesResult)
+        assert result.zone_count == 2
+        names = {z.name for z in result.zones}
+        assert "Office" in names
+        assert "Corridor" in names
+
+    async def test_single_zone(self, client: object, state_with_zones: ServerState) -> None:
+        result = await call_tool(client, "get_zone_properties", {"zone_name": "Office"}, GetZonePropertiesResult)
+        assert result.zone_count == 1
+        assert result.zones[0].name == "Office"
+
+    async def test_unknown_zone_raises(self, client: object, state_with_zones: ServerState) -> None:
+        with pytest.raises(ToolError):
+            await call_tool(client, "get_zone_properties", {"zone_name": "Nonexistent"})
+
+    async def test_zone_with_surface_has_geometry(self, client: object) -> None:
+        state = get_state()
+        doc = new_document()
+        state.document = doc
+        state.schema = doc.schema
+
+        doc.add("Zone", "Room")
+        # Add a simple floor surface with vertices so geometry can be computed
+        doc.add(
+            "BuildingSurface:Detailed",
+            "Room_Floor",
+            surface_type="Floor",
+            construction_name="",
+            zone_name="Room",
+            outside_boundary_condition="Ground",
+            sun_exposure="NoSun",
+            wind_exposure="NoWind",
+            number_of_vertices=4,
+            vertex_1_x_coordinate=0.0,
+            vertex_1_y_coordinate=0.0,
+            vertex_1_z_coordinate=0.0,
+            vertex_2_x_coordinate=5.0,
+            vertex_2_y_coordinate=0.0,
+            vertex_2_z_coordinate=0.0,
+            vertex_3_x_coordinate=5.0,
+            vertex_3_y_coordinate=5.0,
+            vertex_3_z_coordinate=0.0,
+            vertex_4_x_coordinate=0.0,
+            vertex_4_y_coordinate=5.0,
+            vertex_4_z_coordinate=0.0,
+            validate=False,
+        )
+
+        result = await call_tool(client, "get_zone_properties", {"zone_name": "Room"}, GetZonePropertiesResult)
+        zone = result.zones[0]
+        assert zone.surface_counts.floors == 1
+        assert zone.floor_area_m2 is not None
+        assert zone.floor_area_m2 > 0
+
+    async def test_zone_without_surfaces_has_no_geometry(self, client: object) -> None:
+        state = get_state()
+        doc = new_document()
+        state.document = doc
+        state.schema = doc.schema
+        doc.add("Zone", "EmptyRoom")
+
+        result = await call_tool(client, "get_zone_properties", {"zone_name": "EmptyRoom"}, GetZonePropertiesResult)
+        zone = result.zones[0]
+        assert zone.floor_area_m2 is None
+        assert zone.volume_m3 is None
+        assert zone.height_m is None
+
+    async def test_surface_type_counts(self, client: object, state_with_zones: ServerState) -> None:
+        result = await call_tool(client, "get_zone_properties", {"zone_name": "Office"}, GetZonePropertiesResult)
+        zone = result.zones[0]
+        assert zone.surface_counts.walls == 1
+
+    async def test_constructions_collected(self, client: object) -> None:
+        state = get_state()
+        doc = new_document()
+        state.document = doc
+        state.schema = doc.schema
+        doc.add("Zone", "Room")
+        doc.add(
+            "BuildingSurface:Detailed",
+            "Room_Wall",
+            surface_type="Wall",
+            construction_name="ExtWall",
+            zone_name="Room",
+            outside_boundary_condition="Outdoors",
+            sun_exposure="SunExposed",
+            wind_exposure="WindExposed",
+            validate=False,
+        )
+
+        result = await call_tool(client, "get_zone_properties", {"zone_name": "Room"}, GetZonePropertiesResult)
+        assert "ExtWall" in result.zones[0].constructions
+
+    async def test_hvac_connections_named(self, client: object) -> None:
+        state = get_state()
+        doc = new_document()
+        state.document = doc
+        state.schema = doc.schema
+        doc.add("Zone", "Room")
+        doc.add(
+            "ZoneHVAC:EquipmentConnections",
+            "Room_HVAC",
+            zone_name="Room",
+            zone_conditioning_equipment_list_name="",
+            zone_air_inlet_node_or_nodelist_name="",
+            zone_air_exhaust_node_or_nodelist_name="",
+            zone_air_node_name="",
+            zone_return_air_node_or_nodelist_name="",
+            validate=False,
+        )
+
+        result = await call_tool(client, "get_zone_properties", {"zone_name": "Room"}, GetZonePropertiesResult)
+        assert "Room_HVAC" in result.zones[0].hvac_connections

--- a/uv.lock
+++ b/uv.lock
@@ -746,11 +746,11 @@ wheels = [
 
 [[package]]
 name = "idfkit"
-version = "0.6.3"
+version = "0.6.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c1/a2/e3631b9eca9c8599c64673ed25279686cfef184b3a067865e00bb832fbef/idfkit-0.6.3.tar.gz", hash = "sha256:5023a699b8fbec6140efe8fd4205b2e1b952f93c7fa2bd4b2d28e3c1a7331fca", size = 13156824, upload-time = "2026-03-27T21:27:24.64Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3c/a6/188e19d3e9897ed9f94fc13ba74a7211ca7bd8c3f43d458ccc9f3f6130c8/idfkit-0.6.4.tar.gz", hash = "sha256:9d26acaa58b2b27d974e8b501c72e2851c2a15b6d1ee1575d686057dd2708dee", size = 13157249, upload-time = "2026-04-01T02:13:16.101Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/83/17/c220edd37621cfc6b346f9025eccfa9e102849b4d4aa8b7a01986a31b910/idfkit-0.6.3-py3-none-any.whl", hash = "sha256:0f438d838ebe74542d735c9ec74332ab22a7eae2863896d98a6981ccf4b6ad8e", size = 12541120, upload-time = "2026-03-27T21:27:21.724Z" },
+    { url = "https://files.pythonhosted.org/packages/24/3a/91911a28ec5662d7b97f45576381a9308f050c645364cc5227f7b7625113/idfkit-0.6.4-py3-none-any.whl", hash = "sha256:f9b63b444cde6c620bc3e29df932b4821673278e0740d1412fb340c07da6c1b1", size = 12541637, upload-time = "2026-04-01T02:13:18.572Z" },
 ]
 
 [[package]]
@@ -783,7 +783,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "fastmcp", specifier = ">=3.1.0" },
-    { name = "idfkit", specifier = ">=0.6.3" },
+    { name = "idfkit", specifier = ">=0.6.4" },
     { name = "mcp", specifier = ">=1.2.0" },
     { name = "openstudio", specifier = "==3.11.0" },
     { name = "pydantic", specifier = ">=2.0.0" },


### PR DESCRIPTION
## Summary
- New `get_zone_properties` MCP tool returns a typed per-zone summary: floor area, volume, height (computed via `idfkit.geometry`), surface counts by type, referenced constructions, schedules, HVAC connections, and thermostat names
- Bumps `idfkit>=0.6.4` — `calculate_zone_floor_area`, `calculate_zone_volume`, `calculate_zone_height` are new in that release

## Test plan
- [ ] `uv run pytest tests/test_zone_properties_tool.py -v`
- [ ] `uv run pyright src/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)