### PR TITLE
feat: polish server instructions, validate_model docstring

### DIFF
--- a/src/idfkit_mcp/app.py
+++ b/src/idfkit_mcp/app.py
@@ -6,13 +6,36 @@ from fastmcp import FastMCP
 
 from idfkit_mcp.errors import ToolExecutionMiddleware
 
-_INSTRUCTIONS = (
-    "EnergyPlus model authoring via idfkit.\n\n"
-    "Workflow: describe_object_type -> batch_add_objects -> validate_model -> save_model.\n"
-    "Read model state via resources: idfkit://model/summary, idfkit://model/objects/{type}/{name}, "
-    "idfkit://model/references/{name}, idfkit://docs/{type}, idfkit://simulation/results.\n"
-    "Prefer batch_add_objects over repeated add_object calls."
-)
+_INSTRUCTIONS = """EnergyPlus model authoring via idfkit.
+
+VALIDATION LEVELS — two distinct gates, both required for confidence:
+  1. Schema validation (fast, no EnergyPlus required):
+       validate_model        — field types, ranges, required fields, reference integrity (schema only)
+       check_model_integrity — domain QA: orphan objects, missing controls, boundary mismatches
+     Passing these does NOT guarantee a successful simulation.
+  2. Runtime validation (requires EnergyPlus installation):
+       run_simulation        — executes EnergyPlus; fatal errors mean the model is not simulation-ready
+       idfkit://simulation/results — read this resource after every run for the full QA picture:
+         unmet hours by zone, end-use energy breakdown, classified warnings, and actionable QA flags
+
+QA LOOP — the recommended agent workflow:
+  describe_object_type → batch_add_objects → validate_model → check_model_integrity
+  → save_model → run_simulation → read idfkit://simulation/results
+  → fix issues → run_simulation again → repeat until qa_flags is empty
+
+RESOURCES (read-only state, read any time):
+  idfkit://model/summary                     — version, zones, object counts
+  idfkit://model/objects/{type}/{name}       — all field values for one object
+  idfkit://model/references/{name}           — bidirectional reference graph
+  idfkit://docs/{type}                       — documentation URLs
+  idfkit://simulation/results                — post-run QA diagnostics (primary QA signal)
+
+TIPS:
+  - Prefer batch_add_objects over repeated add_object calls
+  - Call describe_object_type before adding any object to learn required fields
+  - get_zone_properties gives a typed summary of zone geometry, surfaces, constructions, and HVAC
+  - get_change_log shows recent mutations in the session
+"""
 
 mcp = FastMCP("idfkit", instructions=_INSTRUCTIONS)
 mcp.add_middleware(ToolExecutionMiddleware())

--- a/src/idfkit_mcp/tools/validation.py
+++ b/src/idfkit_mcp/tools/validation.py
@@ -23,7 +23,20 @@ def validate_model(
     object_types: Annotated[list[str] | None, Field(description="Only validate specific types (default: all).")] = None,
     check_references: Annotated[bool, Field(description="Check reference integrity.")] = True,
 ) -> ValidationResult:
-    """Validate against schema and check references. Run after modifications."""
+    """Schema-based pre-flight check — run after any model modifications.
+
+    Checks field types, numeric ranges, required fields, enum values, singleton
+    constraints (codes E001-E010, W001-W003), and cross-object reference integrity.
+
+    IMPORTANT: This is schema validation only. It does not run EnergyPlus and cannot
+    detect runtime faults such as convergence failures, zone connectivity issues, or
+    autosizing problems. A model that passes this check may still fail to simulate.
+
+    Preconditions: model loaded (load_model or new_model).
+    Side effects: none — read-only.
+    Next steps: check_model_integrity for domain-level QA, then save_model,
+    then run_simulation for definitive runtime validation.
+    """
     from idfkit import validate_document
 
     state = get_state()


### PR DESCRIPTION
## Summary

- Rewrites `_INSTRUCTIONS` in `app.py` to document the two validation levels, QA loop pattern, all resources with descriptions, and usage tips
- Expands `validate_model` docstring to clarify schema-only scope, pre/post conditions, and recommended next steps

## Test plan

- [ ] Server instructions visible via MCP client describe correct workflow
- [ ] `validate_model` docstring accurately describes schema-only validation scope

🤖 Generated with [Claude Code](https://claude.com/claude-code)