### PR TITLE
feat: add include_all_fields option to list_objects

### DIFF
--- a/src/idfkit_mcp/tools/read.py
+++ b/src/idfkit_mcp/tools/read.py
@@ -181,8 +181,23 @@ def convert_osm_to_idf(
 def list_objects(
     object_type: Annotated[str, Field(description='EnergyPlus object type (e.g. "Zone").')],
     limit: Annotated[int, Field(description="Maximum objects to return.")] = 50,
+    include_all_fields: Annotated[
+        bool,
+        Field(
+            description=(
+                "If False (default), each object includes only its name and schema-required fields "
+                "to save tokens. Set True to return every field value for every object."
+            )
+        ),
+    ] = False,
 ) -> ListObjectsResult:
-    """List objects of a type with names and required fields."""
+    """List objects of a type.
+
+    By default each object is returned in brief form: name plus schema-required fields
+    only. Optional fields (economizer settings, enum overrides, etc.) are omitted — set
+    ``include_all_fields=True`` to get every field, or read the
+    ``idfkit://model/objects/{type}/{name}`` resource for one object's full field values.
+    """
     limit = min(limit, 200)
 
     state = get_state()
@@ -193,9 +208,10 @@ def list_objects(
 
     collection = doc.get_collection(object_type)
     total = len(collection)
-    objects = [serialize_object(obj, schema=state.schema, brief=True) for obj in list(collection)[:limit]]
+    brief = not include_all_fields
+    objects = [serialize_object(obj, schema=state.schema, brief=brief) for obj in list(collection)[:limit]]
 
-    logger.debug("list_objects: type=%s total=%d returned=%d", object_type, total, len(objects))
+    logger.debug("list_objects: type=%s total=%d returned=%d brief=%s", object_type, total, len(objects), brief)
     return ListObjectsResult(object_type=object_type, total=total, returned=len(objects), objects=objects)
 
 

--- a/tests/test_read_tools.py
+++ b/tests/test_read_tools.py
@@ -221,6 +221,19 @@ class TestListObjects:
         with pytest.raises(ToolError):
             await call_tool(client, "list_objects", {"object_type": "Material"})
 
+    async def test_include_all_fields(self, client: object, state_with_zones: ServerState) -> None:
+        brief = await call_tool(client, "list_objects", {"object_type": "Zone"}, ListObjectsResult)
+        full = await call_tool(
+            client,
+            "list_objects",
+            {"object_type": "Zone", "include_all_fields": True},
+            ListObjectsResult,
+        )
+        brief_keys = set(brief.objects[0].keys())
+        full_keys = set(full.objects[0].keys())
+        assert brief_keys.issubset(full_keys)
+        assert len(full_keys) > len(brief_keys)
+
 
 class TestSearchObjects:
     async def test_search_by_name(self, client: object, state_with_zones: ServerState) -> None:


### PR DESCRIPTION
## Summary
- `list_objects` was returning only each object's name + schema-required fields, which spooked agents into thinking objects had fewer fields than they really did.
- Added an `include_all_fields: bool = False` parameter that switches to the full field dump when set to `True`; brief remains the default to keep token usage low.
- Updated the docstring to make the brief-by-default behavior explicit and to point callers at the `idfkit://model/objects/{type}/{name}` resource for single-object detail.

## Test plan
- [x] `make check` (ruff, pyright, deptry)
- [x] `make test` (204 passed)
- [x] New `TestListObjects::test_include_all_fields` verifies brief keys ⊂ full keys and full has strictly more fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)