### PR TITLE
Refactor Output:Table:SummaryReports to use extensible groups

### DIFF
--- a/src/idfkit_mcp/serializers.py
+++ b/src/idfkit_mcp/serializers.py
@@ -110,14 +110,29 @@ def get_extensible_group_info(schema: EpJSONSchema, obj_type: str) -> tuple[str 
 
 
 def _example_item(item_fields: list[dict[str, Any]]) -> dict[str, Any]:
-    """Build a one-item example payload for an extensible group."""
+    """Build a one-item example payload for an extensible group.
+
+    Use informative placeholders so agents copying the payload can tell which
+    slots need real values: first enum value for enum fields, an angle-bracketed
+    reference hint for object-list fields, and ``""`` for plain strings.
+    """
     example: dict[str, Any] = {}
     for f in item_fields:
         ftype = f.get("field_type")
         if ftype == "number":
             example[f["name"]] = 0.0
-        else:
-            example[f["name"]] = ""
+            continue
+        enum_values = f.get("enum_values")
+        if enum_values:
+            non_empty = [v for v in enum_values if v]
+            example[f["name"]] = non_empty[0] if non_empty else ""
+            continue
+        if f.get("is_reference"):
+            object_list: list[str] = f.get("object_list") or []
+            target: str = object_list[0] if object_list else "reference"
+            example[f["name"]] = f"<{target}-name>"
+            continue
+        example[f["name"]] = ""
     return example
 
 

--- a/src/idfkit_mcp/tools/simulation.py
+++ b/src/idfkit_mcp/tools/simulation.py
@@ -162,10 +162,7 @@ def _ensure_summary_reports(doc: IDFDocument[Literal[True]]) -> None:
     if "Output:Table:SummaryReports" not in doc:
         doc.add(
             "Output:Table:SummaryReports",
-            fields={
-                f"report_name{'_' + str(i) if i > 1 else ''}": name
-                for i, name in enumerate(sorted(_REQUIRED_SUMMARY_REPORTS), 1)
-            },
+            fields={"reports": [{"report_name": name} for name in sorted(_REQUIRED_SUMMARY_REPORTS)]},
         )
         logger.info("Added Output:Table:SummaryReports with %s", sorted(_REQUIRED_SUMMARY_REPORTS))
         return
@@ -174,16 +171,7 @@ def _ensure_summary_reports(doc: IDFDocument[Literal[True]]) -> None:
     if not obj:
         return
 
-    # Collect existing report names and find the next available index.
-    existing: set[str] = set()
-    idx = 1
-    while True:
-        field = "report_name" if idx == 1 else f"report_name_{idx}"
-        val = getattr(obj, field, None)
-        if val is None:
-            break
-        existing.add(val)
-        idx += 1
+    existing = {group.report_name for group in obj.reports if group.report_name is not None}
 
     # "AllSummary" or "AllSummaryAndMonthly" already include everything.
     if existing & {
@@ -200,9 +188,7 @@ def _ensure_summary_reports(doc: IDFDocument[Literal[True]]) -> None:
         return
 
     for name in sorted(missing):
-        field = "report_name" if idx == 1 else f"report_name_{idx}"
-        setattr(obj, field, name)
-        idx += 1
+        obj.reports.append({"report_name": name})
     logger.info("Added missing summary reports: %s", sorted(missing))
 
 

--- a/tests/test_schema_tools.py
+++ b/tests/test_schema_tools.py
@@ -102,6 +102,38 @@ class TestDescribeObjectType:
         assert result.is_extensible is False
         assert result.extensible_group is None
 
+    async def test_extensible_example_uses_enum_first_value(self, client: object) -> None:
+        """Item fields with enum_values should seed the example with a real value."""
+        result = await call_tool(
+            client,
+            "describe_object_type",
+            {"object_type": "AirLoopHVAC:SupplyPath"},
+            DescribeObjectTypeResult,
+        )
+        assert result.extensible_group is not None
+        wrapper_key = result.extensible_group.key
+        first_item = result.extensible_group.example[wrapper_key][0]
+        enum_field = next(f for f in result.extensible_group.item_fields if f.name == "component_object_type")
+        assert enum_field.enum_values
+        assert first_item["component_object_type"] in enum_field.enum_values
+        assert first_item["component_object_type"] != ""
+
+    async def test_extensible_example_uses_placeholder_for_object_list(self, client: object) -> None:
+        """Object-list (reference) item fields should get a clearly-placeholder string."""
+        result = await call_tool(
+            client,
+            "describe_object_type",
+            {"object_type": "Branch"},
+            DescribeObjectTypeResult,
+        )
+        assert result.extensible_group is not None
+        wrapper_key = result.extensible_group.key
+        first_item = result.extensible_group.example[wrapper_key][0]
+        # component_object_type is an object-list reference -> angle-bracketed placeholder
+        value = first_item["component_object_type"]
+        assert value.startswith("<") and value.endswith(">")
+        assert value != ""
+
 
 class TestSearchSchema:
     async def test_search_zone(self, client: object) -> None:

--- a/tests/test_simulation_tools.py
+++ b/tests/test_simulation_tools.py
@@ -401,63 +401,52 @@ class TestEnsureSummaryReports:
     """Unit tests for _ensure_summary_reports pre-flight function."""
 
     def test_adds_reports_when_missing(self, state_with_model: ServerState) -> None:
-        from idfkit_mcp.tools.simulation import _ensure_summary_reports
+        from idfkit_mcp.tools.simulation import _REQUIRED_SUMMARY_REPORTS, _ensure_summary_reports
 
         doc = state_with_model.require_model()
         assert "Output:Table:SummaryReports" not in doc
         _ensure_summary_reports(doc)
         obj = doc["Output:Table:SummaryReports"].first()
         assert obj is not None
-        from idfkit_mcp.tools.simulation import _REQUIRED_SUMMARY_REPORTS
-
-        assert obj.report_name in _REQUIRED_SUMMARY_REPORTS
+        names = {group.report_name for group in obj.reports}
+        assert names == set(_REQUIRED_SUMMARY_REPORTS)
 
     def test_appends_missing_reports_to_existing(self, state_with_model: ServerState) -> None:
         from idfkit_mcp.tools.simulation import _ensure_summary_reports
 
         doc = state_with_model.require_model()
-        doc.add("Output:Table:SummaryReports", fields={"report_name": "AnnualBuildingUtilityPerformanceSummary"})
+        doc.add(
+            "Output:Table:SummaryReports",
+            fields={"reports": [{"report_name": "AnnualBuildingUtilityPerformanceSummary"}]},
+        )
         _ensure_summary_reports(doc)
         obj = doc["Output:Table:SummaryReports"].first()
+        existing = {group.report_name for group in obj.reports}
         # Original report preserved
-        assert obj.report_name == "AnnualBuildingUtilityPerformanceSummary"
+        assert "AnnualBuildingUtilityPerformanceSummary" in existing
         # New ones appended
-        existing = set()
-        idx = 1
-        while True:
-            field = "report_name" if idx == 1 else f"report_name_{idx}"
-            val = getattr(obj, field, None)
-            if val is None:
-                break
-            existing.add(val)
-            idx += 1
         assert "SensibleHeatGainSummary" in existing
         assert "HVACSizingSummary" in existing
-        assert "AnnualBuildingUtilityPerformanceSummary" in existing
 
     def test_skips_when_all_summary_present(self, state_with_model: ServerState) -> None:
         from idfkit_mcp.tools.simulation import _ensure_summary_reports
 
         doc = state_with_model.require_model()
-        doc.add("Output:Table:SummaryReports", fields={"report_name": "AllSummary"})
+        doc.add("Output:Table:SummaryReports", fields={"reports": [{"report_name": "AllSummary"}]})
         _ensure_summary_reports(doc)
         obj = doc["Output:Table:SummaryReports"].first()
         # Should not append anything — AllSummary covers everything
-        assert obj.report_name == "AllSummary"
-        assert getattr(obj, "report_name_2", None) is None
+        assert [group.report_name for group in obj.reports] == ["AllSummary"]
 
     def test_skips_when_already_present(self, state_with_model: ServerState) -> None:
-        from idfkit_mcp.tools.simulation import _ensure_summary_reports
+        from idfkit_mcp.tools.simulation import _REQUIRED_SUMMARY_REPORTS, _ensure_summary_reports
 
         doc = state_with_model.require_model()
-        from idfkit_mcp.tools.simulation import _REQUIRED_SUMMARY_REPORTS
-
-        data: dict[str, str] = {}
-        for i, name in enumerate(_REQUIRED_SUMMARY_REPORTS, 1):
-            data["report_name" if i == 1 else f"report_name_{i}"] = name
-        doc.add("Output:Table:SummaryReports", fields=data)
+        doc.add(
+            "Output:Table:SummaryReports",
+            fields={"reports": [{"report_name": name} for name in sorted(_REQUIRED_SUMMARY_REPORTS)]},
+        )
         _ensure_summary_reports(doc)
         obj = doc["Output:Table:SummaryReports"].first()
         # Nothing appended beyond what's already there
-        next_field = f"report_name_{len(_REQUIRED_SUMMARY_REPORTS) + 1}"
-        assert getattr(obj, next_field, None) is None
+        assert len(obj.reports) == len(_REQUIRED_SUMMARY_REPORTS)


### PR DESCRIPTION
## Summary
This PR refactors the `Output:Table:SummaryReports` handling to use EnergyPlus's extensible group structure instead of the legacy numbered field pattern (`report_name`, `report_name_2`, etc.). Additionally, it improves example generation for extensible groups by using informative placeholders.

## Key Changes

### Simulation Tools (`src/idfkit_mcp/tools/simulation.py`)
- **Refactored `_ensure_summary_reports()`** to work with the `reports` extensible group instead of numbered `report_name_*` fields
  - When creating new `Output:Table:SummaryReports`, now uses `{"reports": [{"report_name": name}, ...]}` structure
  - When appending missing reports, appends to `obj.reports` list instead of setting numbered attributes
  - Simplified existing report collection by iterating over `obj.reports` directly

### Serializers (`src/idfkit_mcp/serializers.py`)
- **Enhanced `_example_item()`** to generate more informative placeholder values for extensible group examples:
  - **Enum fields**: Uses the first non-empty enum value instead of empty string
  - **Reference fields** (object-list): Uses angle-bracketed placeholder like `<reference-name>` to clearly indicate a reference needs to be filled in
  - **Numeric fields**: Continues to use `0.0`
  - **String fields**: Continues to use empty string `""`

### Tests (`tests/test_simulation_tools.py` and `tests/test_schema_tools.py`)
- **Updated `TestEnsureSummaryReports`** tests to work with the new extensible group structure:
  - Changed test setup to use `{"reports": [{"report_name": ...}]}` format
  - Updated assertions to check `obj.reports` collection instead of numbered attributes
  - Simplified test logic by using set comprehensions over the reports list

- **Added new schema tool tests** (`test_extensible_example_uses_enum_first_value`, `test_extensible_example_uses_placeholder_for_object_list`):
  - Verify that enum fields in extensible group examples use real enum values
  - Verify that object-list reference fields use angle-bracketed placeholders

## Implementation Details
- The refactoring maintains backward compatibility in behavior while modernizing the data structure to match EnergyPlus's extensible group pattern
- Example generation improvements help agents understand which fields require real values vs. which are already populated with sensible defaults

https://claude.ai/code/session_01MyWzdP3KsMgUrJKz8x1Te9