### PR TITLE
chore: bump idfkit to 0.10.2 and surface deprecation warnings on tool responses

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 keywords = ["energyplus", "mcp", "idfkit", "building-energy"]
 requires-python = ">=3.10,<4.0"
 dependencies = [
-    "idfkit==0.10.0",
+    "idfkit==0.10.2",
     "fastmcp[apps]>=3.2.0",
     "mcp>=1.2.0",
     "openstudio==3.11.0",

--- a/src/idfkit_mcp/serializers.py
+++ b/src/idfkit_mcp/serializers.py
@@ -73,13 +73,13 @@ def serialize_object_description(desc: ObjectDescription, schema: EpJSONSchema |
                 "item_fields": item_fields,
                 "example": {wrapper_key: [_example_item(item_fields) for _ in range(3)]},
                 "note": (
-                    f"REQUIRED shape: pass repeated entries as an array under "
-                    f"'{wrapper_key}'. Each item is an object with "
-                    f"{', '.join(item_field_names)}. Do NOT flatten the items "
-                    f"into top-level keys (e.g. '{item_field_names[0]}_2', "
-                    f"'{item_field_names[0]}_3'); flat keys may appear to work "
-                    f"but bypass the structured shape this tool returns and the "
-                    f"shape used by validate_model and the simulation engine."
+                    f"Prefer the structured array form: pass repeated entries "
+                    f"as an array under '{wrapper_key}'. Each item is an object "
+                    f"with {', '.join(item_field_names)}. Flat numbered keys "
+                    f"(e.g. '{item_field_names[0]}_2', '{item_field_names[0]}_3') "
+                    f"are accepted for back-compat but emit a deprecation "
+                    f"warning (surfaced on the tool response) and may be removed "
+                    f"in a future idfkit release."
                 ),
             }
 

--- a/src/idfkit_mcp/tools/write.py
+++ b/src/idfkit_mcp/tools/write.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 import json
 import logging
+import warnings
+from collections.abc import Iterator
+from contextlib import contextmanager
 from typing import Annotated, Any, Literal
 
 from fastmcp.exceptions import ToolError
@@ -27,6 +30,21 @@ logger = logging.getLogger(__name__)
 _MUTATE = ToolAnnotations(readOnlyHint=False, destructiveHint=False, idempotentHint=False, openWorldHint=False)
 _DESTRUCTIVE = ToolAnnotations(readOnlyHint=False, destructiveHint=True, idempotentHint=False, openWorldHint=False)
 _SAVE = ToolAnnotations(readOnlyHint=False, destructiveHint=False, idempotentHint=True, openWorldHint=False)
+
+
+@contextmanager
+def _capture_deprecations() -> Iterator[list[str]]:
+    """Yield a list that, on block exit, holds DeprecationWarning messages emitted inside.
+
+    Lets callers surface idfkit deprecations (e.g. flat-extensible keys like
+    ``vertex_x_coordinate_2``) on the tool response instead of dropping them
+    on the server's stderr where the agent never sees them.
+    """
+    messages: list[str] = []
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always", DeprecationWarning)
+        yield messages
+    messages.extend(str(w.message) for w in caught if issubclass(w.category, DeprecationWarning))
 
 
 @tool(annotations=_MUTATE)
@@ -62,10 +80,14 @@ def add_object(
     state = get_state()
     doc = state.require_model()
     kwargs = fields or {}
-    obj = doc.add(object_type, name, **kwargs)
+    with _capture_deprecations() as deprecations:
+        obj = doc.add(object_type, name, **kwargs)
     logger.info("Added %s %r", object_type, name)
     logger.debug("add_object fields: %s", kwargs)
-    return serialize_object(obj)
+    result = serialize_object(obj)
+    if deprecations:
+        result["warnings"] = deprecations
+    return result
 
 
 @tool(annotations=_MUTATE)
@@ -90,8 +112,12 @@ def batch_add_objects(
 
             obj_name: str = spec.get("name", "")
             obj_fields: dict[str, Any] = spec.get("fields") or {}
-            obj = doc.add(obj_type, obj_name, **obj_fields)
-            results.append({"index": i, **serialize_object(obj, brief=True)})
+            with _capture_deprecations() as deprecations:
+                obj = doc.add(obj_type, obj_name, **obj_fields)
+            entry: dict[str, object] = {"index": i, **serialize_object(obj, brief=True)}
+            if deprecations:
+                entry["warnings"] = deprecations
+            results.append(entry)
             success_count += 1
         except Exception as e:
             results.append({"index": i, "error": str(e)})
@@ -116,12 +142,16 @@ def update_object(
     if obj is None:
         raise ToolError(f"Object '{name}' of type '{object_type}' not found.")
 
-    for field_name, value in fields.items():
-        setattr(obj, field_name, value)
+    with _capture_deprecations() as deprecations:
+        for field_name, value in fields.items():
+            setattr(obj, field_name, value)
 
     logger.info("Updated %s %r (%d fields)", object_type, name, len(fields))
     logger.debug("update_object fields: %s", fields)
-    return serialize_object(obj)
+    result = serialize_object(obj)
+    if deprecations:
+        result["warnings"] = deprecations
+    return result
 
 
 @tool(annotations=_DESTRUCTIVE)

--- a/tests/test_write_tools.py
+++ b/tests/test_write_tools.py
@@ -72,6 +72,8 @@ class TestAddObject:
         assert isinstance(result["vertices"], list)
         assert len(result["vertices"]) == 3
         assert result["vertices"][1]["vertex_x_coordinate"] == 1
+        # Structured form must not surface a deprecation warning.
+        assert "warnings" not in result
 
 
 class TestBatchAddObjects:
@@ -125,6 +127,41 @@ class TestUpdateObject:
             await call_tool(
                 client, "update_object", {"object_type": "Zone", "name": "Missing", "fields": {"x_origin": 5.0}}
             )
+
+    async def test_update_with_flat_extensible_key_surfaces_deprecation_warning(
+        self, client: object, state_with_model: ServerState
+    ) -> None:
+        """Updating an extensible field via a flat numbered key emits a deprecation warning."""
+        await call_tool(
+            client,
+            "add_object",
+            {
+                "object_type": "BuildingSurface:Detailed",
+                "name": "Wall1",
+                "fields": {
+                    "surface_type": "Wall",
+                    "construction_name": "C1",
+                    "zone_name": "Z1",
+                    "outside_boundary_condition": "Outdoors",
+                    "vertices": [
+                        {"vertex_x_coordinate": 0, "vertex_y_coordinate": 0, "vertex_z_coordinate": 0},
+                        {"vertex_x_coordinate": 1, "vertex_y_coordinate": 0, "vertex_z_coordinate": 0},
+                        {"vertex_x_coordinate": 1, "vertex_y_coordinate": 0, "vertex_z_coordinate": 1},
+                    ],
+                },
+            },
+        )
+        result = await call_tool(
+            client,
+            "update_object",
+            {
+                "object_type": "BuildingSurface:Detailed",
+                "name": "Wall1",
+                "fields": {"vertex_z_coordinate_1": 2.5},
+            },
+        )
+        assert "warnings" in result
+        assert any("deprecated" in w.lower() for w in result["warnings"])
 
 
 class TestRemoveObject:

--- a/uv.lock
+++ b/uv.lock
@@ -751,11 +751,11 @@ wheels = [
 
 [[package]]
 name = "idfkit"
-version = "0.10.0"
+version = "0.10.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/cb/6b/8b1c8d20bedbef74aa6abe5ceecbd1bbb7e1e7e51f9380e14fe64d97242a/idfkit-0.10.0.tar.gz", hash = "sha256:609be14c44b8f5389f099d23fa149b3596c582d147fa0a34cbdba1e2702ac996", size = 15184655, upload-time = "2026-04-27T14:02:23.487Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/13/55/00d680e97710d8ad5a1e5ad573509a0c780f15b8b697a63b015c6eab9084/idfkit-0.10.2.tar.gz", hash = "sha256:d44659da8cd1ea10353eb61acc29d2ada2c538497fca61b66e78a221a864a8d9", size = 15186805, upload-time = "2026-04-28T01:16:39.83Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/07/12/2b7c294b8c9ed4ed1ba4d3e70f07b7c71ca04d5423661d986f9e97992159/idfkit-0.10.0-py3-none-any.whl", hash = "sha256:c694865ef75464db00cad59d6f2b535461ad864d5c0b8def7013073434660f18", size = 14021015, upload-time = "2026-04-27T14:02:20.369Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/fc/576a523a669656c4f948aa4469b9ca56255f6ce0e937459102550c55588a/idfkit-0.10.2-py3-none-any.whl", hash = "sha256:39d3f3c8882d7e436e1caf99cd4d0e21dfcf85a55275f08fc1245e644d9ebf8c", size = 14021718, upload-time = "2026-04-28T01:16:37.308Z" },
 ]
 
 [[package]]
@@ -788,7 +788,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "fastmcp", extras = ["apps"], specifier = ">=3.2.0" },
-    { name = "idfkit", specifier = "==0.10.0" },
+    { name = "idfkit", specifier = "==0.10.2" },
     { name = "mcp", specifier = ">=1.2.0" },
     { name = "openstudio", specifier = "==3.11.0" },
     { name = "pydantic", specifier = ">=2.0.0" },


### PR DESCRIPTION
## Summary

- Bump `idfkit` from 0.10.0 to 0.10.2 to pick up the [union field_type fix](https://github.com/idfkit/idfkit/pull/142). `describe_object_type` now reports e.g. `Schedule:Compact`'s extensible `field` as `"number|string"` instead of the misleading `"number"`, so agents see the field is actually heterogeneous.
- Surface idfkit `DeprecationWarning`s — previously dropped on the server's stderr where the agent never sees them — under a `warnings` key on `add_object` / `update_object` / `batch_add_objects` responses. This lets agents self-correct when they use deprecated forms (e.g. flat extensible keys like `vertex_x_coordinate_2`).
- Soften the `extensible_group` note to match reality: flat keys are accepted and silently translated by idfkit, so the prior wording ("Do NOT flatten ... bypass the structured shape used by validate_model and the simulation engine") was empirically false.

## Coverage gap (forward-compatible)

`update_object`'s `setattr` path emits the deprecation today (covered by a regression test). `add_object` / `batch_add_objects` go through idfkit's `doc.add(**kwargs)` → `_normalize_extensible_input`, which rewrites flat keys silently in 0.10.2. A follow-up idfkit PR will plumb the deprecation through that path; the wrapper here is forward-compatible and will surface those messages automatically once a new idfkit release lands.

## Test plan

- [x] `make check` passes (ruff, pyright 0 errors, deptry clean)
- [x] `make test` — all 222 tests pass, including:
  - `test_extensible_array_form_succeeds` (now also asserts no `warnings` key on the structured form)
  - `test_update_with_flat_extensible_key_surfaces_deprecation_warning` (new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)