### PR TITLE
chore: bump idfkit to 0.10.3 and add flat-kwargs deprecation regression tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 keywords = ["energyplus", "mcp", "idfkit", "building-energy"]
 requires-python = ">=3.10,<4.0"
 dependencies = [
-    "idfkit==0.10.2",
+    "idfkit==0.10.3",
     "fastmcp[apps]>=3.2.0",
     "mcp>=1.2.0",
     "openstudio==3.11.0",

--- a/tests/test_write_tools.py
+++ b/tests/test_write_tools.py
@@ -75,6 +75,44 @@ class TestAddObject:
         # Structured form must not surface a deprecation warning.
         assert "warnings" not in result
 
+    async def test_flat_extensible_keys_surface_deprecation_warning(
+        self, client: object, state_with_model: ServerState
+    ) -> None:
+        """Flat-numbered extensible kwargs still work but the response must surface idfkit's deprecation.
+
+        idfkit 0.10.3 emits the warning from ``_normalize_extensible_input`` when ``.add()``
+        rewrites flat kwargs to the canonical wrapper form, so the response wrapper picks
+        it up and exposes it under ``warnings``.
+        """
+        result = await call_tool(
+            client,
+            "add_object",
+            {
+                "object_type": "BuildingSurface:Detailed",
+                "name": "FlatWall",
+                "fields": {
+                    "surface_type": "Wall",
+                    "construction_name": "C1",
+                    "zone_name": "Z1",
+                    "outside_boundary_condition": "Outdoors",
+                    "vertex_x_coordinate_1": 0,
+                    "vertex_y_coordinate_1": 0,
+                    "vertex_z_coordinate_1": 0,
+                    "vertex_x_coordinate_2": 1,
+                    "vertex_y_coordinate_2": 0,
+                    "vertex_z_coordinate_2": 0,
+                    "vertex_x_coordinate_3": 1,
+                    "vertex_y_coordinate_3": 0,
+                    "vertex_z_coordinate_3": 1,
+                },
+            },
+        )
+        assert result["name"] == "FlatWall"
+        assert isinstance(result["vertices"], list)
+        assert len(result["vertices"]) == 3
+        assert "warnings" in result
+        assert any("deprecated" in w.lower() for w in result["warnings"])
+
 
 class TestBatchAddObjects:
     async def test_batch_add(self, client: object, state_with_model: ServerState) -> None:
@@ -102,6 +140,37 @@ class TestBatchAddObjects:
         objects = [{"name": "Test"}]
         result = await call_tool(client, "batch_add_objects", {"objects": objects}, BatchAddResult)
         assert result.errors == 1
+
+    async def test_batch_attaches_deprecation_warnings_per_entry(
+        self, client: object, state_with_model: ServerState
+    ) -> None:
+        """Per-object deprecation warnings should appear only on the entry that triggered them."""
+        objects = [
+            {"object_type": "Zone", "name": "ZoneA"},
+            {
+                "object_type": "BuildingSurface:Detailed",
+                "name": "FlatWall",
+                "fields": {
+                    "surface_type": "Wall",
+                    "construction_name": "C1",
+                    "zone_name": "ZoneA",
+                    "outside_boundary_condition": "Outdoors",
+                    "vertex_x_coordinate_1": 0,
+                    "vertex_y_coordinate_1": 0,
+                    "vertex_z_coordinate_1": 0,
+                    "vertex_x_coordinate_2": 1,
+                    "vertex_y_coordinate_2": 0,
+                    "vertex_z_coordinate_2": 0,
+                    "vertex_x_coordinate_3": 1,
+                    "vertex_y_coordinate_3": 0,
+                    "vertex_z_coordinate_3": 1,
+                },
+            },
+        ]
+        result = await call_tool(client, "batch_add_objects", {"objects": objects}, BatchAddResult)
+        assert result.success == 2
+        assert "warnings" not in result.results[0]
+        assert "warnings" in result.results[1]
 
 
 class TestUpdateObject:

--- a/uv.lock
+++ b/uv.lock
@@ -751,11 +751,11 @@ wheels = [
 
 [[package]]
 name = "idfkit"
-version = "0.10.2"
+version = "0.10.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/13/55/00d680e97710d8ad5a1e5ad573509a0c780f15b8b697a63b015c6eab9084/idfkit-0.10.2.tar.gz", hash = "sha256:d44659da8cd1ea10353eb61acc29d2ada2c538497fca61b66e78a221a864a8d9", size = 15186805, upload-time = "2026-04-28T01:16:39.83Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e2/32/81b9d4f25323eb17a1d8e7aa4f00bf9da98b6fa2dfe801fb9b1d12248399/idfkit-0.10.3.tar.gz", hash = "sha256:61162dcce49f3c5fbaefd80a2f094e84acb9e49f132227e31cf829f3cc949f26", size = 15187244, upload-time = "2026-04-28T01:30:42.056Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a5/fc/576a523a669656c4f948aa4469b9ca56255f6ce0e937459102550c55588a/idfkit-0.10.2-py3-none-any.whl", hash = "sha256:39d3f3c8882d7e436e1caf99cd4d0e21dfcf85a55275f08fc1245e644d9ebf8c", size = 14021718, upload-time = "2026-04-28T01:16:37.308Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/ce/6853445203075a2ee0a8216bcdb4999555cb0b6d81caa2738815e0c91401/idfkit-0.10.3-py3-none-any.whl", hash = "sha256:57e0aea8d056bee751fa05815150d3487b626dd2e10acfdd5b53bb04371faea7", size = 14021833, upload-time = "2026-04-28T01:30:39.135Z" },
 ]
 
 [[package]]
@@ -788,7 +788,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "fastmcp", extras = ["apps"], specifier = ">=3.2.0" },
-    { name = "idfkit", specifier = "==0.10.2" },
+    { name = "idfkit", specifier = "==0.10.3" },
     { name = "mcp", specifier = ">=1.2.0" },
     { name = "openstudio", specifier = "==3.11.0" },
     { name = "pydantic", specifier = ">=2.0.0" },


### PR DESCRIPTION
## Summary

- Bumps `idfkit` 0.10.2 → 0.10.3 to pick up [idfkit#143](https://github.com/idfkit/idfkit/pull/143), which emits a `DeprecationWarning` from `IDFDocument._normalize_extensible_input` whenever `.add()` rewrites flat-extensible kwargs (e.g. `vertex_x_coordinate_2`) to the canonical wrapper-array form.
- The `_capture_deprecations` wrapper added in #63 already captures any `DeprecationWarning` emitted during the call, so `add_object` and `batch_add_objects` now surface the same signal that `update_object`'s setattr path already did — closing the coverage gap I called out in #63.
- Adds the two regression tests that were forward-compatible with the wrapper but waited on the idfkit emit:
  - `TestAddObject.test_flat_extensible_keys_surface_deprecation_warning`
  - `TestBatchAddObjects.test_batch_attaches_deprecation_warnings_per_entry`

## Test plan

- [x] `make check` passes (ruff, pyright 0 errors, deptry clean)
- [x] `make test` — all 224 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)