### PR TITLE
chore(deps): bump idfkit to 0.11.0 and drop redundant casts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 keywords = ["energyplus", "mcp", "idfkit", "building-energy"]
 requires-python = ">=3.10,<4.0"
 dependencies = [
-    "idfkit==0.10.3",
+    "idfkit==0.11.0",
     "fastmcp[apps]>=3.2.0",
     "mcp>=1.2.0",
     "openstudio==3.11.0",

--- a/src/idfkit_mcp/tools/schedule.py
+++ b/src/idfkit_mcp/tools/schedule.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import json
 import logging
 from datetime import date
-from typing import Annotated
+from typing import TYPE_CHECKING, Annotated
 
 from fastmcp.apps import AppConfig, ResourceCSP, app_config_to_meta_dict
 from fastmcp.resources.function_resource import resource
@@ -15,6 +15,9 @@ from pydantic import Field
 
 from idfkit_mcp.schedule_viewer import SCHEDULE_VIEWER_HTML
 from idfkit_mcp.state import get_state
+
+if TYPE_CHECKING:
+    from idfkit import IDFDocument, IDFObject
 
 logger = logging.getLogger(__name__)
 
@@ -41,16 +44,14 @@ _ALL_SCHEDULE_TYPES = (
 _MAX_SCHEDULES = 30
 
 
-def _resolve_type_limits(doc: object, limits_name: str | None) -> dict[str, object] | None:
+def _resolve_type_limits(doc: IDFDocument[bool], limits_name: str | None) -> dict[str, object] | None:
     """Look up ScheduleTypeLimits and extract bounds."""
     if not limits_name:
         return None
-    collection = doc.get_collection("ScheduleTypeLimits")  # type: ignore[union-attr]
+    collection = doc.get_collection("ScheduleTypeLimits")
     if not collection:
         return None
-    from typing import Any, cast
-
-    obj: Any = cast(Any, collection).get(limits_name)
+    obj = collection.get(limits_name)
     if obj is None:
         return None
     lower = getattr(obj, "lower_limit_value", None)
@@ -59,24 +60,24 @@ def _resolve_type_limits(doc: object, limits_name: str | None) -> dict[str, obje
     unit_type = getattr(obj, "unit_type", None) or "Dimensionless"
     return {
         "name": limits_name,
-        "lower": float(lower) if lower is not None else None,  # type: ignore[arg-type]
-        "upper": float(upper) if upper is not None else None,  # type: ignore[arg-type]
+        "lower": float(lower) if lower is not None else None,
+        "upper": float(upper) if upper is not None else None,
         "numericType": str(numeric_type),
         "unitType": str(unit_type),
     }
 
 
 def _evaluate_one(
-    obj: object,
+    obj: IDFObject,
     obj_type: str,
-    doc: object,
+    doc: IDFDocument[bool],
     year: int,
 ) -> dict[str, object] | None:
     """Evaluate a single schedule object, returning None on failure."""
     from idfkit.schedules.evaluate import ScheduleEvaluationError, values
 
     try:
-        vals = values(obj, year=year, document=doc)  # type: ignore[arg-type]
+        vals = values(obj, year=year, document=doc)
     except ScheduleEvaluationError as e:
         logger.warning("Failed to evaluate schedule '%s': %s", getattr(obj, "name", "?"), e)
         return None
@@ -91,19 +92,17 @@ def _evaluate_one(
 
 def _find_schedule_by_name(
     name: str,
-    doc: object,
+    doc: IDFDocument[bool],
     year: int,
 ) -> tuple[list[dict[str, object]], list[str]]:
     """Search all schedule types for a specific named schedule."""
-    from typing import Any, cast
-
     schedules: list[dict[str, object]] = []
     skipped: list[str] = []
     for obj_type in _ALL_SCHEDULE_TYPES:
-        collection = doc.get_collection(obj_type)  # type: ignore[union-attr]
+        collection = doc.get_collection(obj_type)
         if not collection:
             continue
-        obj: Any = cast(Any, collection).get(name)
+        obj = collection.get(name)
         if obj is not None:
             result = _evaluate_one(obj, obj_type, doc, year)
             if result is not None:
@@ -118,16 +117,14 @@ def _find_schedule_by_name(
 
 
 def _collect_all_schedules(
-    doc: object,
+    doc: IDFDocument[bool],
     year: int,
 ) -> tuple[list[dict[str, object]], list[str]]:
     """Collect and evaluate all top-level schedules from the model."""
-    from typing import Any, cast
-
     schedules: list[dict[str, object]] = []
     skipped: list[str] = []
     for obj_type in _TOP_LEVEL_SCHEDULE_TYPES:
-        collection: Any = cast(Any, doc).get_collection(obj_type)
+        collection = doc.get_collection(obj_type)
         if not collection:
             continue
         for obj in collection:

--- a/uv.lock
+++ b/uv.lock
@@ -751,11 +751,11 @@ wheels = [
 
 [[package]]
 name = "idfkit"
-version = "0.10.3"
+version = "0.11.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e2/32/81b9d4f25323eb17a1d8e7aa4f00bf9da98b6fa2dfe801fb9b1d12248399/idfkit-0.10.3.tar.gz", hash = "sha256:61162dcce49f3c5fbaefd80a2f094e84acb9e49f132227e31cf829f3cc949f26", size = 15187244, upload-time = "2026-04-28T01:30:42.056Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3c/28/38c9a4a5eca35a20960f28ffa4719d0619dc562904665e949b047c25bf6d/idfkit-0.11.0.tar.gz", hash = "sha256:b529a5f95d628f0c5ee8be02fb8db308f4f7dcf4c82fbf705cd27450aeca4deb", size = 15188656, upload-time = "2026-04-28T11:54:14.888Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a5/ce/6853445203075a2ee0a8216bcdb4999555cb0b6d81caa2738815e0c91401/idfkit-0.10.3-py3-none-any.whl", hash = "sha256:57e0aea8d056bee751fa05815150d3487b626dd2e10acfdd5b53bb04371faea7", size = 14021833, upload-time = "2026-04-28T01:30:39.135Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/00/680c39b68fa1ff1ac55e9f36e4151444f1bc9d804af26a245274f80a7c60/idfkit-0.11.0-py3-none-any.whl", hash = "sha256:2cf7a55365c1f2726f3b41510403fbeb4eed70c595a4438eea733cdd6d66f771", size = 14022901, upload-time = "2026-04-28T11:54:18.448Z" },
 ]
 
 [[package]]
@@ -788,7 +788,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "fastmcp", extras = ["apps"], specifier = ">=3.2.0" },
-    { name = "idfkit", specifier = "==0.10.3" },
+    { name = "idfkit", specifier = "==0.11.0" },
     { name = "mcp", specifier = ">=1.2.0" },
     { name = "openstudio", specifier = "==3.11.0" },
     { name = "pydantic", specifier = ">=2.0.0" },


### PR DESCRIPTION
## Summary

- Bumps `idfkit` from `0.10.3` to `0.11.0` (regenerated `uv.lock`).
- Drops three `cast(Any, ...).get(...)` calls in `tools/schedule.py` that were defending against the now-narrowed `IDFCollection.get` and `IDFDocument.get_collection` return types.
- Types the schedule helpers' `doc` / `obj` parameters as `IDFDocument` / `IDFObject` so the new `@overload`-based signatures (idfkit PRs #145-#148) flow through correctly. As a bonus, several `# type: ignore` comments are also gone.

## Test plan

- [x] `uv lock && uv sync`
- [x] `uv run pyright src/idfkit_mcp/tools/schedule.py` -> 0 errors
- [x] `make check` (ruff + pyright + deptry) -> all green
- [x] `make test` -> 224 passed
- [x] `uv run pytest tests/test_integration.py::TestCreateEditValidateSave::test_full_workflow -v` -> passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)