### PR TITLE
feat: add remove_objects tool for replace-all collection editing

### DIFF
--- a/src/idfkit_mcp/models.py
+++ b/src/idfkit_mcp/models.py
@@ -281,6 +281,14 @@ class RemoveObjectResult(BaseModel):
     name: str
 
 
+class RemoveObjectsResult(BaseModel):
+    """Response from ``remove_objects``."""
+
+    status: str
+    object_type: str
+    removed: int
+
+
 class RenameObjectResult(BaseModel):
     """Response from ``rename_object``."""
 

--- a/src/idfkit_mcp/tools/write.py
+++ b/src/idfkit_mcp/tools/write.py
@@ -19,6 +19,7 @@ from idfkit_mcp.models import (
     ClearSessionResult,
     NewModelResult,
     RemoveObjectResult,
+    RemoveObjectsResult,
     RenameObjectResult,
     SaveModelResult,
 )
@@ -179,6 +180,56 @@ def remove_object(
     doc.removeidfobject(obj)
     logger.info("Removed %s %r", object_type, obj.name)
     return RemoveObjectResult(status="removed", object_type=object_type, name=obj.name)
+
+
+@tool(annotations=_DESTRUCTIVE)
+def remove_objects(
+    object_type: Annotated[str, Field(description="EnergyPlus object type.")],
+    force: Annotated[
+        bool,
+        Field(description="Remove even if some entries are referenced by other objects."),
+    ] = False,
+) -> RemoveObjectsResult:
+    """Delete every object of the given type. No-op when none exist.
+
+    Intended for types where individual entries have no canonical addressable
+    identity (``Output:Variable``, ``Output:Meter``, …): those parse with
+    ``_name=""`` to support duplicates, so ``remove_object`` cannot reach them
+    individually. Use this when the calling tool owns the entire collection
+    and wants replace-all semantics (e.g. an output-picker UI).
+
+    Blocked when any entry is referenced by other objects unless ``force=True``.
+    """
+    state = get_state()
+    doc = state.require_model()
+
+    if object_type not in doc:
+        return RemoveObjectsResult(status="removed", object_type=object_type, removed=0)
+
+    collection = doc.get_collection(object_type)
+    items = list(collection)
+    if not items:
+        return RemoveObjectsResult(status="removed", object_type=object_type, removed=0)
+
+    if not force:
+        blockers: list[dict[str, str]] = []
+        for obj in items:
+            if not obj.name:
+                continue
+            referencing = doc.get_referencing(obj.name)
+            for r in referencing:
+                blockers.append({"object_type": r.obj_type, "name": r.name})
+        if blockers:
+            raise ToolError(
+                "Some objects are referenced by other objects. "
+                f"Use force=True to remove anyway.\n{json.dumps(blockers)}"
+            )
+
+    for obj in items:
+        doc.removeidfobject(obj)
+
+    logger.info("Removed all %s (%d objects)", object_type, len(items))
+    return RemoveObjectsResult(status="removed", object_type=object_type, removed=len(items))
 
 
 @tool(annotations=_MUTATE)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -31,6 +31,7 @@ class TestCreateServer:
             "batch_add_objects",
             "update_object",
             "remove_object",
+            "remove_objects",
             "rename_object",
             "duplicate_object",
             "save_model",

--- a/tests/test_write_tools.py
+++ b/tests/test_write_tools.py
@@ -5,7 +5,14 @@ from __future__ import annotations
 import pytest
 from fastmcp.exceptions import ToolError
 
-from idfkit_mcp.models import BatchAddResult, NewModelResult, RemoveObjectResult, RenameObjectResult, SaveModelResult
+from idfkit_mcp.models import (
+    BatchAddResult,
+    NewModelResult,
+    RemoveObjectResult,
+    RemoveObjectsResult,
+    RenameObjectResult,
+    SaveModelResult,
+)
 from idfkit_mcp.state import ServerState, get_state
 from tests.conftest import call_tool
 
@@ -249,6 +256,47 @@ class TestRemoveObject:
             client, "remove_object", {"object_type": "Zone", "name": "Office", "force": True}, RemoveObjectResult
         )
         assert result.status == "removed"
+
+
+class TestRemoveObjects:
+    async def test_remove_all_nameless(self, client: object, state_with_model: ServerState) -> None:
+        # has_name=False types (Output:Meter) parse with _name="" so they can't
+        # be removed via remove_object — bulk-remove is the supported escape.
+        await call_tool(
+            client,
+            "batch_add_objects",
+            {
+                "objects": [
+                    {
+                        "object_type": "Output:Meter",
+                        "fields": {"key_name": "Electricity:Facility", "reporting_frequency": "Hourly"},
+                    },
+                    {
+                        "object_type": "Output:Meter",
+                        "fields": {"key_name": "DistrictCooling:Plant", "reporting_frequency": "Timestep"},
+                    },
+                ]
+            },
+            BatchAddResult,
+        )
+        result = await call_tool(client, "remove_objects", {"object_type": "Output:Meter"}, RemoveObjectsResult)
+        assert result.status == "removed"
+        assert result.removed == 2
+        assert "Output:Meter" not in state_with_model.document  # type: ignore[operator]
+
+    async def test_remove_missing_type_is_noop(self, client: object, state_with_model: ServerState) -> None:
+        result = await call_tool(client, "remove_objects", {"object_type": "Output:Meter"}, RemoveObjectsResult)
+        assert result.status == "removed"
+        assert result.removed == 0
+
+    async def test_remove_referenced_blocked(self, client: object, state_with_zones: ServerState) -> None:
+        with pytest.raises(ToolError, match="referenced"):
+            await call_tool(client, "remove_objects", {"object_type": "Zone"})
+
+    async def test_remove_referenced_forced(self, client: object, state_with_zones: ServerState) -> None:
+        result = await call_tool(client, "remove_objects", {"object_type": "Zone", "force": True}, RemoveObjectsResult)
+        assert result.status == "removed"
+        assert result.removed >= 1
 
 
 class TestRenameObject:


### PR DESCRIPTION
## Summary

- Adds a new MCP tool `remove_objects(object_type, force=False)` that deletes every entry of a given type in one call.
- Intended for `has_name=False` collections (`Output:Variable`, `Output:Meter`, …) where individual entries parse with `_name=""` by design and aren't reachable through `remove_object`.
- Mirrors `remove_object`'s safety contract: blocked when any entry is referenced unless `force=True`. No-op when the type isn't present in the model.

## Motivation

idfkit deliberately sets `_name=""` for `has_name=False` types so duplicate entries (e.g. multiple `Output:Variable` rows with `key_value="*"`) round-trip correctly through parse/write — see commit `066c226` in idfkit. The trade-off is that `IDFCollection.get(name)` only matches `_name`, so callers that own a whole collection (e.g. a UI picker that replaces the user's `Output:Variable` / `Output:Meter` selection on every apply) had no way to clear it.

The picker in [powerbox-app](https://github.com/Carbon-Signal/powerbox-app)'s output-selection flow was the immediate driver: it pre-populates from the model, lets the user edit, then re-applies. Without a bulk-remove escape, removals from the picker silently fail to propagate to the simulated IDF.

`remove_object` stays the right tool for named, individually-addressable objects. `remove_objects` is the escape for replace-all flows over unnamed collections.

## Test plan

- [x] New `TestRemoveObjects` class in `tests/test_write_tools.py`:
  - removes all entries of an `has_name=False` type (`Output:Meter`) — the case the existing tooling can't address
  - is a no-op when the type isn't in the model
  - is blocked by referenced objects unless `force=True`
  - clears a referenced named collection with `force=True`
- [x] `tests/test_server.py` updated so the tool-registration assertion covers the new name
- [x] `pytest tests/test_server.py tests/test_write_tools.py` — 44 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)