### PR TITLE
fix(ci): write CNAME into docs/ so Pages keeps the custom domain

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -52,6 +52,9 @@ jobs:
           # Copy built docs into /docs subdirectory
           mkdir -p docs
           cp -r ../site/. docs/
+          # GitHub Pages publishes from /docs, so CNAME must live there too —
+          # otherwise the custom domain gets cleared on each deploy.
+          cp ../gh-pages-extra/CNAME docs/CNAME
           touch .nojekyll
 
           git config user.name "github-actions[bot]"

--- a/.github/workflows/deploy-pr-docs.yml
+++ b/.github/workflows/deploy-pr-docs.yml
@@ -73,7 +73,9 @@ jobs:
           rm -rf "$DEST"
           mkdir -p "$DEST"
           cp -r site/. "$DEST/"
+          # GitHub Pages publishes from /docs, so CNAME must live there as well as at the root.
           printf 'mcp.idfkit.com\n' > gh-pages-deploy/CNAME
+          printf 'mcp.idfkit.com\n' > gh-pages-deploy/docs/CNAME
 
           cd gh-pages-deploy
           git config user.name "github-actions[bot]"


### PR DESCRIPTION
## Summary
- GitHub Pages on this repo publishes from `gh-pages:/docs` (confirmed by the PR preview URL `mcp.idfkit.com/pr-preview/pr-N/` mapping to `gh-pages-deploy/docs/pr-preview/pr-N/`).
- Both deploy workflows only placed `CNAME` at the branch root. The build step then overwrote `docs/` with the freshly built site, which contains no CNAME — so Pages saw a published folder without CNAME and cleared the custom domain on every run.
- This adds `mcp.idfkit.com` to `docs/CNAME` in both `deploy-docs.yml` (main deploy) and `deploy-pr-docs.yml` (PR previews), alongside the existing root CNAME.

## Why not switch to `peaceiris/actions-gh-pages`?
The sibling repo `idfkit/idfkit` doesn't have this problem because it uses `peaceiris/actions-gh-pages@v4` with `cname: py.idfkit.com`, which writes CNAME into the published folder automatically. Keeping the custom script here but fixing the CNAME placement is the smallest change.

## Follow-up
After this merges, re-set the custom domain to `mcp.idfkit.com` once in Settings → Pages. Subsequent deploys will preserve it.

## Test plan
- [ ] Merge and confirm `mcp.idfkit.com` survives the next `deploy-docs` run.
- [ ] Open a PR after merge and confirm the preview deploy doesn't reset the domain either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)