### PR TITLE
docs: reconcile tool count, EnergyPlus range, and stability claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,17 +19,20 @@ Built on [idfkit](https://github.com/idfkit/idfkit), it supports **EnergyPlus 8.
 
 ## Tools
 
-The server exposes **32 tools** across seven categories:
+The server exposes **37 tools** across ten categories, plus **13 MCP resources** for read-only data access:
 
 | Category | Tools | What they do |
 | --- | --- | --- |
 | **Schema** | 4 | Explore object types, fields, constraints, and valid references |
-| **Model Read** | 7 | Load IDF/epJSON/OSM files, inspect objects, search, and trace references |
-| **Model Write** | 9 | Create models, add/update/remove/rename/duplicate objects, save, and manage sessions |
-| **Validation** | 2 | Schema validation and dangling-reference detection |
-| **Simulation** | 5 | Run EnergyPlus, summarize results, query output variables, and export time series |
+| **Model Read** | 6 | Load IDF/epJSON/OSM files, inspect objects, search, and read change history |
+| **Model Write** | 10 | Create models, add/update/remove/rename/duplicate objects, save, and manage sessions |
+| **Validation** | 2 | Schema validation and pre-simulation integrity checks |
+| **Simulation** | 8 | Run EnergyPlus, query variables and tabular reports, export time series, analyze peak loads, and view reports |
 | **Weather** | 2 | Search weather stations worldwide and download EPW/DDY files |
-| **Documentation** | 3 | Look up, search, and read EnergyPlus documentation from [docs.idfkit.com](https://docs.idfkit.com) |
+| **Geometry** | 1 | Interactive 3D building geometry viewer (MCP Apps) |
+| **Schedules** | 1 | Interactive schedule heatmap viewer (MCP Apps) |
+| **Migration** | 1 | Migrate IDF models forward across EnergyPlus versions |
+| **Documentation** | 2 | Search and read EnergyPlus documentation from [docs.idfkit.com](https://docs.idfkit.com) |
 
 All tools return structured Pydantic models. Schema, validation, and search results include direct `doc_url` links to the relevant EnergyPlus documentation.
 

--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -28,10 +28,10 @@ graph TB
 
     subgraph Core["idfkit (core library)"]
         Parser["IDF / epJSON Parser"]
-        Schema["Bundled Schemas<br/><small>EnergyPlus 8.9 &ndash; 25.2</small>"]
+        Schema["Bundled Schemas<br/><small>EnergyPlus 8.9 &ndash; 26.1</small>"]
         Validator["Validator"]
         SimRunner["Simulation Runner"]
-        WeatherIdx["Weather Station Index<br/><small>16,000+ stations</small>"]
+        WeatherIdx["Weather Station Index<br/><small>~17,300 unique stations</small>"]
         Docs["Doc URL Builder"]
     end
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -9,9 +9,14 @@ hide:
 # idfkit-mcp
 
 <p class="hero-tagline">
-A production-ready MCP server for EnergyPlus workflows: schema discovery,
+An MCP server for EnergyPlus workflows: schema discovery,
 model editing, integrity checks, QA diagnostics, peak-load analysis, and simulation via idfkit.
 </p>
+
+!!! warning "Beta"
+    idfkit-mcp is in active beta. APIs and tool shapes may change between
+    minor versions. We're looking for early adopters and testers —
+    [share feedback on GitHub](https://github.com/idfkit/idfkit-mcp/issues).
 
 <div class="badges" markdown>
 
@@ -32,7 +37,7 @@ model editing, integrity checks, QA diagnostics, peak-load analysis, and simulat
 
 <div class="feature-chips" markdown>
 
-<span class="chip">:material-tools: 35 MCP tools</span>
+<span class="chip">:material-tools: 37 MCP tools</span>
 <span class="chip">:material-shape-outline: Schema-aware edits</span>
 <span class="chip">:material-shield-check-outline: Validation + integrity checks</span>
 <span class="chip">:material-weather-cloudy: Weather search + download</span>

--- a/docs/tools/index.md
+++ b/docs/tools/index.md
@@ -1,17 +1,18 @@
 # Tool Reference Overview
 
-`idfkit-mcp` exposes **35 tools** in nine categories, plus **12 MCP resources** for read-only data access.
+`idfkit-mcp` exposes **37 tools** in ten categories, plus **13 MCP resources** for read-only data access.
 
 ## Categories
 
 - Schema exploration: 4 tools
 - Model read: 6 tools
-- Model write: 9 tools
+- Model write: 10 tools
 - Validation: 2 tools
 - Simulation: 8 tools
 - Geometry: 1 tool
 - Schedules: 1 tool
 - Weather: 2 tools
+- Migration: 1 tool
 - Documentation: 2 tools
 
 ## Tool Catalog
@@ -33,6 +34,7 @@
 | Write | `batch_add_objects` | Add many objects in one call |
 | Write | `update_object` | Update fields on one object |
 | Write | `remove_object` | Remove object, optionally forced |
+| Write | `remove_objects` | Remove many objects in one call |
 | Write | `rename_object` | Rename object and cascade references |
 | Write | `duplicate_object` | Clone object to a new name |
 | Write | `save_model` | Save IDF/epJSON |
@@ -51,6 +53,7 @@
 | Weather | `download_weather_file` | Download EPW/DDY and cache path |
 | Geometry | `view_geometry` | Interactive 3D building geometry viewer (MCP Apps) |
 | Schedules | `view_schedules` | Interactive schedule heatmap viewer (MCP Apps) |
+| Migration | `migrate_model` | Migrate IDF models forward across EnergyPlus versions |
 | Documentation | `search_docs` | Full-text search across EnergyPlus documentation |
 | Documentation | `get_doc_section` | Retrieve full content of a documentation section |
 
@@ -68,6 +71,7 @@ Read-only data is available via MCP resources without making tool calls:
 | `idfkit://simulation/results` | Structured QA diagnostics from the most recent simulation |
 | `idfkit://simulation/peak-loads` | Peak heating/cooling load decomposition and QA analysis |
 | `idfkit://simulation/report` | Full tabular simulation report as JSON |
+| `idfkit://migration/report` | Per-step stdout/stderr, structural diff, and versions for the last `migrate_model` run |
 | `ui://idfkit/geometry-viewer.html` | Interactive Three.js geometry viewer (MCP Apps) |
 | `ui://idfkit/schedule-viewer.html` | Interactive schedule heatmap viewer (MCP Apps) |
 | `ui://idfkit/peak-loads-viewer.html` | Interactive peak load QA/QC viewer (MCP Apps) |


### PR DESCRIPTION
## Summary

Three different MCP tool counts were live across the ecosystem (`idfkit.com=25`, `README=32`, `mcp.idfkit.com=35`) when the actual count is **37** (verified by grepping `@tool` decorators across `src/idfkit_mcp/tools/`). Two different EnergyPlus upper bounds were also in play (`25.2` vs `26.1`) when `versions.py` supports through `26.1`. This PR brings README + docs in line with the code.

### Changes

- **`README.md`**: `32 tools / seven categories` → `37 tools / ten categories, plus 13 MCP resources`. Per-category counts corrected to match decorator reality (Read 7→6, Write 9→10, Sim 5→8, Docs 3→2; added Geometry, Schedules, Migration rows).
- **`docs/index.md`**: hero chip `35 MCP tools` → `37 MCP tools`. Dropped "production-ready" wording and added an explicit Beta admonition. Per the audit decision, both idfkit and idfkit-mcp are positioned as beta — no contradictions between sites.
- **`docs/tools/index.md`**: header counts fixed; catalog table now includes the previously-missing `remove_objects`, `migrate_model`, and `idfkit://migration/report` rows.
- **`docs/concepts/architecture.md`**: Mermaid diagram `EnergyPlus 8.9 – 25.2` → `8.9 – 26.1`. Weather station count `16,000+` → `~17,300 unique` (matches idfkit's actual WMO unique count).

### Companion PRs

- `idfkit/idfkit#161` — fix `__version__` to read from package metadata; bump `pyproject.toml` to `0.12.2`; correct stale weather-station counts in README & docs.
- `idfkit/idfkit.com` (separate PR, same branch) — sync MCP tool count, EP range, and weather-station hero stat with ground truth.

## Test plan

- [ ] `make docs` renders `docs/index.md`, `docs/tools/index.md`, and `docs/concepts/architecture.md` without errors.
- [ ] Tool catalog table on `mcp.idfkit.com/docs/tools/` shows 37 rows across 10 categories.
- [ ] Mermaid architecture diagram renders with `EnergyPlus 8.9 – 26.1` and `~17,300 unique stations`.
- [ ] Hero chip on landing page reads `37 MCP tools`.

https://claude.ai/code/session_017WyEWRf3BQkxcVc5bz7hfj

---
_Generated by [Claude Code](https://claude.ai/code/session_017WyEWRf3BQkxcVc5bz7hfj)_